### PR TITLE
Fix broken GIF link

### DIFF
--- a/archive/libgdxjam.com/viewEntry2e08.html
+++ b/archive/libgdxjam.com/viewEntry2e08.html
@@ -42,7 +42,7 @@
 					<div class="section-header">Links</div>
 					<div class="section-content">
 						<a href="https://github.com/bigbass1997/Light-Explosions/releases/latest" target="_blank">Jar</a><br><a href="https://github.com/bigbass1997/Light-Explosions" target="_blank">Source</a><br><a
-							href="../cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif" target="_blank">Preview GIF</a><br>
+							href="https://cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif" target="_blank">Preview GIF</a><br>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This changes the "Preview GIF" link from https://libgdx.com/archive/cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif (which unsurprisingly doesn't go anywhere) to https://cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif.