### PR TITLE
HTTPS for nightly download link

### DIFF
--- a/_pages/dev/-tutorials/generate.md
+++ b/_pages/dev/-tutorials/generate.md
@@ -13,7 +13,7 @@ header:
     - label: "Stable Release"
       url: "/assets/downloads/legacy_setup/gdx-setup_latest.jar"
     - label: "Nightly Version"
-      url: "http://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar"
+      url: "https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar"
 
 excerpt: "libGDX offers a setup tool, which automatically creates a project and downloads everything necessary."
 


### PR DESCRIPTION
In commit [5de254eaead5d494d6427832fce57a554ef144e9](https://github.com/libgdx/libgdx.github.io/commit/5de254eaead5d494d6427832fce57a554ef144e9) the nightlies download link was changed to use the HTTP protocol. Security aside, since libgdx.com is loaded over HTTPS, this prevents Chrome users (and presumably anything Chromium-based) from downloading the nightly version.

`Mixed Content: The site at 'https://libgdx.com/' was loaded over a secure connection, but the file at 'http://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar' was loaded over an insecure connection. This file should be served over HTTPS. This download has been blocked. See https://blog.chromium.org/2020/02/protecting-users-from-insecure.html for more details.`