### PR TITLE
Update legal.md

### DIFF
--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -4,8 +4,8 @@ title: "Legal"
 classes: wide2
 ---
 
-This site is operated by the [libGDX project](https://github.com/libgdx/libgdx). It is hosted by [GitHub](https://github.com) using [GitHub Pages](https://docs.github.com/en/github/working-with-github-pages/about-github-pages). The GitHub Privacy Statement is available [here](https://docs.github.com/en/github/site-policy/github-privacy-statement).
+This site is operated by the [libGDX project](https://github.com/libgdx/libgdx). It is hosted by [GitHub](https://github.com) using [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages). The GitHub Privacy Statement is available [here](https://docs.github.com/en/github/site-policy/github-privacy-statement).
 
 Please note that GitHub may collect User Personal Information, as defined in the GitHub Privacy Statement, from visitors, including logs of visitor IP addresses, to comply with legal obligations, and to maintain the security and integrity of the Website and the Service.
 
-Some pages of this website embed Youtube videos. This service is provided by the Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA. Their Privacy Statement can be found [here](https://policies.google.com/privacy).
+Some pages of this website embed YouTube videos. This service is provided by the Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA. Their Privacy Statement can be found [here](https://policies.google.com/privacy).


### PR DESCRIPTION
I've done two things here:

1. Replaced the GitHub Pages link with the address the current link now redirects to.
2. Changed "Youtube" to "YouTube" (why am I writing this when you can see it for yourself in the changes?) because the incorrect capitalisation is upsetting me.

P.S. Before today I didn't know the website stuff was on GitHub. But now it is time to hit the hay.