### PR TITLE
CSS dark mode

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,12 +15,12 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
-<!-- Light mode; for all browsers -->
+<!-- Light mode -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
-<!-- Dark mode; inspired by https://github.com/mmistakes/minimal-mistakes/discussions/2033#discussioncomment-257421 -->
+<!-- Dark mode -->
 {% if site.minimal_mistakes_skin_dark %}
-  <meta name="color-scheme" content="dark light">
+  <meta name="color-scheme" content="light dark">
   <style>
     @import url("{{ '/assets/css/main2.css' | relative_url }}") (prefers-color-scheme: dark);
   </style>


### PR DESCRIPTION
This maybe fixes #26, albeit not in the most ideal way since two large stylesheets are still getting sent to the browser instead of the dark mode stylesheet only overriding what's necessary, though in spite of seeing `_dark.scss` I don't know how to improve that. Don't think we can download only a single stylesheet whilst maintaining support for all browsers (old ones if using CSS3; ones without JS enabled if using JS).

While I'm not getting the white flash between each page, that could be due to testing locally-ish (iPod connected to the computer - can't find any dark mode settings on my computer that actually affect websites). But an improvement I can definitely attribute to this is the page automatically updates if the user's light/dark mode changes whilst viewing it. And working without JavaScript is cool in itself.

I don't think `<meta name="color-scheme" content="dark light">` really does anything for this website, but I added it anyway since it's only one line and should make systemy things like checkboxes and whatnot match the dark theme when using it. Could also achieve the same thing with the `color-scheme` CSS property.

***

P.S. Can we just remove line 11? Wherever that's meant to link to, it doesn't exist anymore.

https://github.com/libgdx/libgdx.github.io/blob/aa1852107d73a659063f26cc2c876f70b7556acf/_includes/head.html#L11-L12