### PR TITLE
Change selection color from black to libGDX red

### DIFF
--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -99,6 +99,14 @@ html, body {
   overflow-x: hidden;
 }
 
+::-moz-selection {
+  background: #e74a45;
+}
+
+::selection {
+  background: #e74a45;
+}
+
 .grid__item {
   .archive__item-teaser {
       @include breakpoint($small) {


### PR DESCRIPTION
Exactly what it sounds like. I feel like the theme's black selection colour doesn't match the libGDX vibes and is difficult to see on dark mode, so here's a red version - the very same `#e74a45` used in the logo, though semi-transparency may change this a little.

![Comparison](https://user-images.githubusercontent.com/60154347/131416106-f9eac0bb-7007-460d-8f82-41f4811e0890.png)

A subjective change - can be left open for discussion if necessary.