### PR TITLE
Fix image widths on showcase page for mobile

### DIFF
--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -18,42 +18,42 @@ The following collection of games built with libGDX gives an impression of what 
 
 We fused card games and rogue-likes together to make the best single player deckbuilder we could. Craft a unique deck, encounter bizarre creatures, discover relics of immense power, and Slay the Spire!
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Mindustry](https://store.steampowered.com/app/1127400/Mindustry/) by AnukenDev, using the [Arc](https://github.com/Anuken/Arc) fork <a href="https://github.com/Anuken/Mindustry" style="margin-left: 10px" class="btn btn--primary">On GitHub</a>
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/1127400/header.jpg?t=1586887170" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 An open-ended tower-defense game with a focus on resource management. Create elaborate supply chains of conveyor belts to feed ammo into your turrets, produce materials to use for building, and defend your structures from waves of enemies.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Space Haven](https://store.steampowered.com/app/979110/Space_Haven/) by Bugbyte Ltd.
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/979110/header.jpg?t=1596215195" style="margin-right: 25px; margin-top: 17px; margin-bottom:25px" class="lazyload">
 
 Embark on a space voyage with your ragtag crew in search of a new home. Build spaceships tile by tile, manage the needs and moods of their crew, encounter other space-faring groups, and explore the universe in this spaceship colony simulation.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Delver](https://store.steampowered.com/app/249630/Delver/) by Priority Interrupt <span style="margin-left: 1px" class="btn btn--success">3D</span>
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/249630/header.jpg?t=1584136307" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Delve into the shifting dungeons on your hunt for the Yithidian orb, but getting it might just be the easy part. Delver is a single player first-person action roguelike dungeon crawler, just like you wished they used to make.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Pathway](https://store.steampowered.com/app/546430/Pathway/) by Robotality
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/546430/header.jpg?t=1593431294" style="margin-right: 25px; margin-top: 17px; margin-bottom:15px" class="lazyload">
 
 Explore the strange unknown with Pathway, a strategy adventure set in the 1930s great wilderness. Unravel long-forgotten mysteries of the occult, raid ancient tombs and outwit your foes in turn-based squad combat!
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Halfway](https://store.steampowered.com/app/253150/Halfway/) by Robotality
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/253150/header.jpg?t=1593431340" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Halfway is a turn-based strategy RPG taking place a few hundred years into the future. Humanity has started colonising new worlds. Until now, they were alone...
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 
 ## [Space Grunts 2](https://store.steampowered.com/app/1125370/Space_Grunts_2/) by Orangepixel
@@ -62,28 +62,28 @@ Halfway is a turn-based strategy RPG taking place a few hundred years into the f
 
 Space Grunts 2 combines some of the fastest turn-based gameplay with card-battling mechanics in a 1950's sci-fi roguelike setting.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Riiablo](https://github.com/collinsmith/riiablo) by collinsmith <a href="https://github.com/collinsmith/riiablo" style="margin-right: 10px" class="btn btn--primary">On GitHub</a> <span class="btn btn--success">3D</span>
 <img align="right" src="/assets/images/showcase/riiablo.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:20px; max-width: 460px; max-height: 240px;" class="lazyload">
 
 Riiablo is a Diablo II remake using Java and libGDX. As a hero of humanity, you must face the minions of Diablo's evil brothers and stop the Dark Wanderer before he fulfills his terrible destiny.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Raindancer](https://store.steampowered.com/app/1156000/Raindancer/) by Strange Creatures Studio
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/1156000/header.jpg?t=1574896868" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Awoken from death by The Rain itself, Bramble is tasked with bringing an end to the leaders of three rival tribes, and purifying their corruption against nature.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Rifter](https://store.steampowered.com/app/625740/Rifter/) by IMakeGames
 <img align="right" src="https://cdn.cloudflare.steamstatic.com/steam/apps/625740/header.jpg?t=1533076306" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Breathtakingly fast and tough-as-nails, Rifter is an acrobatic platformer drenched in neon and infused with a pumping 80’s synthwave soundtrack. Run, swing, smash and dash at exhilarating speeds on a quest to discover the secrets of a shattered world.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 <br/>
 <br/>
@@ -96,70 +96,70 @@ libGDX really shines if you plan to release games for mobile platforms as well!
 
 Battle your way through a dangerous digital world and save it from an evil virus with the help of your favorite Disney and Pixar heroes! It’s no-holds barred in this battle-packed RPG starring heroes from Frozen, Wall-E, Toy Story, The Lion King, Pirates of the Caribbean, and more.  [[Android](https://play.google.com/store/apps/details?id=com.perblue.disneyheroes) / [iOS](https://itunes.apple.com/us/app/disney-heroes-battle-mode/id1327925104?mt=8)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Sandship](http://rockbitegames.com/sandship/) by Rockbite Games
 <img align="right" src="https://play-lh.googleusercontent.com/zVcowfZOhVnUaYCRDu5YkLTczk7eHG2JeVoHZ36aY249O1I0Mm2e_f_IqzPsDNzUug=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Sandship is a factory management game set in a post-apocalyptic sci-fi universe. You control the last remaining sandship: a gigantic, artificially intelligent mega-factory, which roams across the endless deserts of a far-away planet. [[Android](https://play.google.com/store/apps/details?id=com.rockbite.sandship) / [iOS](https://apps.apple.com/us/app/sandship-crafting-factory/id1440385758)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Zombie Age 3](https://divmob.com/1853-zombie-age-3.html) by DIVMOB
 <img align="left" src="https://play-lh.googleusercontent.com/Lv75VsRcaJ4IJAW8CWZCW1_owedvAvyRdyanaEnPCxFFdbitVAx27NHN2uITJUpAa94=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 The awesome Zombie Age series returns with a lot more of savage zombies, deadly weapons and unique heroes. Enjoy the zombie slaughter with your own style. And If you’re about to look for a stunning zombie shooting game, look no further! [[Android](https://play.google.com/store/apps/details?id=com.redantz.game.zombie3&hl=en) / [iOS](https://apps.apple.com/us/app/zombie-age-3-dead-city/id1479541251)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Deep Town](http://rockbitegames.com/deep-town/) by Rockbite Games
 <img align="right" src="https://play-lh.googleusercontent.com/LWZCyc_QVaXX1PBj3qByh38mc5ppWq3ZzevM8C4U13exF6JKMyO_JW9PEXSHZJ51Msw=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 DIG DEEP and uncover the hidden story behind Deep Town and along the way discover story artifacts, dig deeper, and build mining stations to produce more resources! [[Android](https://play.google.com/store/apps/details?id=com.rockbite.deeptown&hl=en) / [iOS](https://apps.apple.com/us/app/deep-town-bergbaubetrieb/id1202240058)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Epic Heroes War](https://divmob.com/1700-epic-heroes-war.html) by DIVMOB
 <img align="left" src="https://play-lh.googleusercontent.com/2DsYF54m5GVjUVAuBedCfIw-O3F-sVo56FcDwwuQYz-aekdRwESRuXkNDDEF9Xc-kN8=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Epic Heroes War is a real-time strategy game, online side-scroller defense combines RPG. Build up a powerful army and slaughter enemy hordes in quests and battles with other players! [[Android](https://play.google.com/store/apps/details?id=com.divmob.ageofheroes.braveheroes.battleheroes.epicheroeswar.epicheroes.en) / [iOS](https://apps.apple.com/us/app/epic-heroes-war/id1530763834)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Shattered Pixel Dungeon](https://shatteredpixel.com) by Shattered Pixel <a href="https://github.com/00-Evan/shattered-pixel-dungeon" style="margin-left: 10px" class="btn btn--primary">On GitHub</a>
 <img align="right" src="https://images-na.ssl-images-amazon.com/images/I/51MadCajQaL.png" style="margin-left: 25px; margin-top: 17px; margin-bottom:25px; max-width: 460px; max-height: 215px" class="lazyload">
 
 Shattered Pixel Dungeon is a Roguelike RPG, with pixel art graphics and lots of variety and replayability. Every game is unique, with four different playable characters, randomized levels, and over 150 items to collect and use. [[Android](https://play.google.com/store/apps/details?id=com.shatteredpixel.shatteredpixeldungeon) / [Desktop](https://github.com/00-Evan/shattered-pixel-dungeon/blob/master/docs/getting-started-desktop.md#quick-setup)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Unciv](https://github.com/yairm210/Unciv) by Yair Morgenstern <a href="https://github.com/yairm210/Unciv" style="margin-left 10px" class="btn btn--primary">On GitHub</a>
 <img align="left" src="https://play-lh.googleusercontent.com/l8fuQ2DnNjoD9pFnHLsli1xt8OClfr6O9GSBJJ9w7IIb2VHOyxqKZ9lNZXtMqOabCfyI=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 An open-source reimplementation of the most famous civilization-building game ever - fast, small, no ads, free forever! Build your civilization, research technologies, expand your cities and defeat your foes! [[Android](https://play.google.com/store/apps/details?id=com.unciv.app) / [Desktop](https://yairm210.itch.io/unciv)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Tap Wizard](https://www.ironhorsegames.org/games-2) by Iron Horse Games
 <img align="right" src="https://play-lh.googleusercontent.com/PVAdazFzDbNnvyq4nP6DdC6Lm3E1nCTP4iyTfywV0dw-I1w7LuNV9zftKladsI5UWg=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Tap Wizard is an Idle Action-RPG like no other! Equip your Wizard with a loadout of Spells to decimate over 60 unique hordes of enemies! The best part? You can sit back and watch as the Wizard does all the hard work! [[Android](https://play.google.com/store/apps/details?id=com.topcog.tapwizardrpgarcanequest) / [iOS](https://apps.apple.com/us/app/tap-wizard-rpg-arcane-quest/id1369751082)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Mirage Realms](http://www.miragerealms.co.uk/devblog/) by Liam Stewart
 <img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px; max-width: 460px; max-height: 240px" class="lazyload">
 
 Mirage Realms is an ambitious solo project to produce a free to play MMORPG for different platforms. [[Android](https://play.google.com/store/apps/details?id=com.foxcake.mirage.android) / [Desktop](https://www.miragerealms.co.uk/devblog/play/)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [PokeMMO](https://pokemmo.eu/)
 <img align="right" src="https://pokemmo.eu/images/screenshot/c-t.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 PokeMMO, a fan-made, free-to-play MMORPG based on the Pokémon games. Welcome to a new era of online monster battles! [[Android](https://pokemmo.eu/downloads/android/) / [Desktop](https://pokemmo.eu/downloads/)]
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>
 
 <br/>
 <br/>
@@ -172,4 +172,4 @@ There are also some non-game applications made with libGDX.
 
 Spine is an animation tool that focuses specifically on 2D animation for games. Spine aims to have an efficient, streamlined workflow, both for creating animations using the editor and for making use of those animations in games.
 
-<div style="clear: both;with: 100%; height: 1px;"></div>
+<div style="clear: both;width: 100%; height: 1px;"></div>

--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -18,42 +18,42 @@ The following collection of games built with libGDX gives an impression of what 
 
 We fused card games and rogue-likes together to make the best single player deckbuilder we could. Craft a unique deck, encounter bizarre creatures, discover relics of immense power, and Slay the Spire!
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Mindustry](https://store.steampowered.com/app/1127400/Mindustry/) by AnukenDev, using the [Arc](https://github.com/Anuken/Arc) fork <a href="https://github.com/Anuken/Mindustry" style="margin-left: 10px" class="btn btn--primary">On GitHub</a>
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/1127400/header.jpg?t=1586887170" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 An open-ended tower-defense game with a focus on resource management. Create elaborate supply chains of conveyor belts to feed ammo into your turrets, produce materials to use for building, and defend your structures from waves of enemies.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Space Haven](https://store.steampowered.com/app/979110/Space_Haven/) by Bugbyte Ltd.
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/979110/header.jpg?t=1596215195" style="margin-right: 25px; margin-top: 17px; margin-bottom:25px" class="lazyload">
 
 Embark on a space voyage with your ragtag crew in search of a new home. Build spaceships tile by tile, manage the needs and moods of their crew, encounter other space-faring groups, and explore the universe in this spaceship colony simulation.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Delver](https://store.steampowered.com/app/249630/Delver/) by Priority Interrupt <span style="margin-left: 1px" class="btn btn--success">3D</span>
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/249630/header.jpg?t=1584136307" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Delve into the shifting dungeons on your hunt for the Yithidian orb, but getting it might just be the easy part. Delver is a single player first-person action roguelike dungeon crawler, just like you wished they used to make.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Pathway](https://store.steampowered.com/app/546430/Pathway/) by Robotality
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/546430/header.jpg?t=1593431294" style="margin-right: 25px; margin-top: 17px; margin-bottom:15px" class="lazyload">
 
 Explore the strange unknown with Pathway, a strategy adventure set in the 1930s great wilderness. Unravel long-forgotten mysteries of the occult, raid ancient tombs and outwit your foes in turn-based squad combat!
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Halfway](https://store.steampowered.com/app/253150/Halfway/) by Robotality
 <img align="right" src="https://steamcdn-a.akamaihd.net/steam/apps/253150/header.jpg?t=1593431340" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Halfway is a turn-based strategy RPG taking place a few hundred years into the future. Humanity has started colonising new worlds. Until now, they were alone...
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 
 ## [Space Grunts 2](https://store.steampowered.com/app/1125370/Space_Grunts_2/) by Orangepixel
@@ -62,28 +62,28 @@ Halfway is a turn-based strategy RPG taking place a few hundred years into the f
 
 Space Grunts 2 combines some of the fastest turn-based gameplay with card-battling mechanics in a 1950's sci-fi roguelike setting.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Riiablo](https://github.com/collinsmith/riiablo) by collinsmith <a href="https://github.com/collinsmith/riiablo" style="margin-right: 10px" class="btn btn--primary">On GitHub</a> <span class="btn btn--success">3D</span>
 <img align="right" src="/assets/images/showcase/riiablo.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:20px; max-height: 240px;" class="lazyload">
 
 Riiablo is a Diablo II remake using Java and libGDX. As a hero of humanity, you must face the minions of Diablo's evil brothers and stop the Dark Wanderer before he fulfills his terrible destiny.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Raindancer](https://store.steampowered.com/app/1156000/Raindancer/) by Strange Creatures Studio
 <img align="left" src="https://steamcdn-a.akamaihd.net/steam/apps/1156000/header.jpg?t=1574896868" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Awoken from death by The Rain itself, Bramble is tasked with bringing an end to the leaders of three rival tribes, and purifying their corruption against nature.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Rifter](https://store.steampowered.com/app/625740/Rifter/) by IMakeGames
 <img align="right" src="https://cdn.cloudflare.steamstatic.com/steam/apps/625740/header.jpg?t=1533076306" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Breathtakingly fast and tough-as-nails, Rifter is an acrobatic platformer drenched in neon and infused with a pumping 80’s synthwave soundtrack. Run, swing, smash and dash at exhilarating speeds on a quest to discover the secrets of a shattered world.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 <br/>
 <br/>
@@ -96,70 +96,70 @@ libGDX really shines if you plan to release games for mobile platforms as well!
 
 Battle your way through a dangerous digital world and save it from an evil virus with the help of your favorite Disney and Pixar heroes! It’s no-holds barred in this battle-packed RPG starring heroes from Frozen, Wall-E, Toy Story, The Lion King, Pirates of the Caribbean, and more.  [[Android](https://play.google.com/store/apps/details?id=com.perblue.disneyheroes) / [iOS](https://itunes.apple.com/us/app/disney-heroes-battle-mode/id1327925104?mt=8)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Sandship](http://rockbitegames.com/sandship/) by Rockbite Games
 <img align="right" src="https://play-lh.googleusercontent.com/zVcowfZOhVnUaYCRDu5YkLTczk7eHG2JeVoHZ36aY249O1I0Mm2e_f_IqzPsDNzUug=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Sandship is a factory management game set in a post-apocalyptic sci-fi universe. You control the last remaining sandship: a gigantic, artificially intelligent mega-factory, which roams across the endless deserts of a far-away planet. [[Android](https://play.google.com/store/apps/details?id=com.rockbite.sandship) / [iOS](https://apps.apple.com/us/app/sandship-crafting-factory/id1440385758)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Zombie Age 3](https://divmob.com/1853-zombie-age-3.html) by DIVMOB
 <img align="left" src="https://play-lh.googleusercontent.com/Lv75VsRcaJ4IJAW8CWZCW1_owedvAvyRdyanaEnPCxFFdbitVAx27NHN2uITJUpAa94=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 The awesome Zombie Age series returns with a lot more of savage zombies, deadly weapons and unique heroes. Enjoy the zombie slaughter with your own style. And If you’re about to look for a stunning zombie shooting game, look no further! [[Android](https://play.google.com/store/apps/details?id=com.redantz.game.zombie3&hl=en) / [iOS](https://apps.apple.com/us/app/zombie-age-3-dead-city/id1479541251)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Deep Town](http://rockbitegames.com/deep-town/) by Rockbite Games
 <img align="right" src="https://play-lh.googleusercontent.com/LWZCyc_QVaXX1PBj3qByh38mc5ppWq3ZzevM8C4U13exF6JKMyO_JW9PEXSHZJ51Msw=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 DIG DEEP and uncover the hidden story behind Deep Town and along the way discover story artifacts, dig deeper, and build mining stations to produce more resources! [[Android](https://play.google.com/store/apps/details?id=com.rockbite.deeptown&hl=en) / [iOS](https://apps.apple.com/us/app/deep-town-bergbaubetrieb/id1202240058)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Epic Heroes War](https://divmob.com/1700-epic-heroes-war.html) by DIVMOB
 <img align="left" src="https://play-lh.googleusercontent.com/2DsYF54m5GVjUVAuBedCfIw-O3F-sVo56FcDwwuQYz-aekdRwESRuXkNDDEF9Xc-kN8=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Epic Heroes War is a real-time strategy game, online side-scroller defense combines RPG. Build up a powerful army and slaughter enemy hordes in quests and battles with other players! [[Android](https://play.google.com/store/apps/details?id=com.divmob.ageofheroes.braveheroes.battleheroes.epicheroeswar.epicheroes.en) / [iOS](https://apps.apple.com/us/app/epic-heroes-war/id1530763834)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Shattered Pixel Dungeon](https://shatteredpixel.com) by Shattered Pixel <a href="https://github.com/00-Evan/shattered-pixel-dungeon" style="margin-left: 10px" class="btn btn--primary">On GitHub</a>
 <img align="right" src="https://images-na.ssl-images-amazon.com/images/I/51MadCajQaL.png" style="margin-left: 25px; margin-top: 17px; margin-bottom:25px; max-height: 215px" class="lazyload">
 
 Shattered Pixel Dungeon is a Roguelike RPG, with pixel art graphics and lots of variety and replayability. Every game is unique, with four different playable characters, randomized levels, and over 150 items to collect and use. [[Android](https://play.google.com/store/apps/details?id=com.shatteredpixel.shatteredpixeldungeon) / [Desktop](https://github.com/00-Evan/shattered-pixel-dungeon/blob/master/docs/getting-started-desktop.md#quick-setup)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Unciv](https://github.com/yairm210/Unciv) by Yair Morgenstern <a href="https://github.com/yairm210/Unciv" style="margin-left 10px" class="btn btn--primary">On GitHub</a>
 <img align="left" src="https://play-lh.googleusercontent.com/l8fuQ2DnNjoD9pFnHLsli1xt8OClfr6O9GSBJJ9w7IIb2VHOyxqKZ9lNZXtMqOabCfyI=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 An open-source reimplementation of the most famous civilization-building game ever - fast, small, no ads, free forever! Build your civilization, research technologies, expand your cities and defeat your foes! [[Android](https://play.google.com/store/apps/details?id=com.unciv.app) / [Desktop](https://yairm210.itch.io/unciv)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Tap Wizard](https://www.ironhorsegames.org/games-2) by Iron Horse Games
 <img align="right" src="https://play-lh.googleusercontent.com/PVAdazFzDbNnvyq4nP6DdC6Lm3E1nCTP4iyTfywV0dw-I1w7LuNV9zftKladsI5UWg=w460-h215-r" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 Tap Wizard is an Idle Action-RPG like no other! Equip your Wizard with a loadout of Spells to decimate over 60 unique hordes of enemies! The best part? You can sit back and watch as the Wizard does all the hard work! [[Android](https://play.google.com/store/apps/details?id=com.topcog.tapwizardrpgarcanequest) / [iOS](https://apps.apple.com/us/app/tap-wizard-rpg-arcane-quest/id1369751082)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [Mirage Realms](http://www.miragerealms.co.uk/devblog/) by Liam Stewart
 <img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px; max-height: 240px" class="lazyload">
 
 Mirage Realms is an ambitious solo project to produce a free to play MMORPG for different platforms. [[Android](https://play.google.com/store/apps/details?id=com.foxcake.mirage.android) / [Desktop](https://www.miragerealms.co.uk/devblog/play/)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [PokeMMO](https://pokemmo.eu/)
 <img align="right" src="https://pokemmo.eu/images/screenshot/c-t.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:10px" class="lazyload">
 
 PokeMMO, a fan-made, free-to-play MMORPG based on the Pokémon games. Welcome to a new era of online monster battles! [[Android](https://pokemmo.eu/downloads/android/) / [Desktop](https://pokemmo.eu/downloads/)]
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>
 
 <br/>
 <br/>
@@ -172,4 +172,4 @@ There are also some non-game applications made with libGDX.
 
 Spine is an animation tool that focuses specifically on 2D animation for games. Spine aims to have an efficient, streamlined workflow, both for creating animations using the editor and for making use of those animations in games.
 
-<div style="clear: both;width: 100%; height: 1px;"></div>
+<div style="clear: both; width: 100%; height: 1px;"></div>

--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -147,7 +147,7 @@ Tap Wizard is an Idle Action-RPG like no other! Equip your Wizard with a loadout
 
 <div style="clear: both; width: 100%; height: 1px;"></div>
 
-## [Mirage Realms](http://www.miragerealms.co.uk/devblog/) by Liam Stewart
+## [Mirage Realms](https://www.miragerealms.co.uk/devblog/) by Liam Stewart
 <img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px; max-height: 240px" class="lazyload">
 
 Mirage Realms is an ambitious solo project to produce a free to play MMORPG for different platforms. [[Android](https://play.google.com/store/apps/details?id=com.foxcake.mirage.android) / [Desktop](https://www.miragerealms.co.uk/devblog/play/)]

--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -65,7 +65,7 @@ Space Grunts 2 combines some of the fastest turn-based gameplay with card-battli
 <div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Riiablo](https://github.com/collinsmith/riiablo) by collinsmith <a href="https://github.com/collinsmith/riiablo" style="margin-right: 10px" class="btn btn--primary">On GitHub</a> <span class="btn btn--success">3D</span>
-<img align="right" src="/assets/images/showcase/riiablo.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:20px; max-width: 460px; max-height: 240px;" class="lazyload">
+<img align="right" src="/assets/images/showcase/riiablo.jpg" style="margin-left: 25px; margin-top: 17px; margin-bottom:20px; max-height: 240px;" class="lazyload">
 
 Riiablo is a Diablo II remake using Java and libGDX. As a hero of humanity, you must face the minions of Diablo's evil brothers and stop the Dark Wanderer before he fulfills his terrible destiny.
 
@@ -127,7 +127,7 @@ Epic Heroes War is a real-time strategy game, online side-scroller defense combi
 <div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Shattered Pixel Dungeon](https://shatteredpixel.com) by Shattered Pixel <a href="https://github.com/00-Evan/shattered-pixel-dungeon" style="margin-left: 10px" class="btn btn--primary">On GitHub</a>
-<img align="right" src="https://images-na.ssl-images-amazon.com/images/I/51MadCajQaL.png" style="margin-left: 25px; margin-top: 17px; margin-bottom:25px; max-width: 460px; max-height: 215px" class="lazyload">
+<img align="right" src="https://images-na.ssl-images-amazon.com/images/I/51MadCajQaL.png" style="margin-left: 25px; margin-top: 17px; margin-bottom:25px; max-height: 215px" class="lazyload">
 
 Shattered Pixel Dungeon is a Roguelike RPG, with pixel art graphics and lots of variety and replayability. Every game is unique, with four different playable characters, randomized levels, and over 150 items to collect and use. [[Android](https://play.google.com/store/apps/details?id=com.shatteredpixel.shatteredpixeldungeon) / [Desktop](https://github.com/00-Evan/shattered-pixel-dungeon/blob/master/docs/getting-started-desktop.md#quick-setup)]
 
@@ -148,7 +148,7 @@ Tap Wizard is an Idle Action-RPG like no other! Equip your Wizard with a loadout
 <div style="clear: both;width: 100%; height: 1px;"></div>
 
 ## [Mirage Realms](http://www.miragerealms.co.uk/devblog/) by Liam Stewart
-<img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px; max-width: 460px; max-height: 240px" class="lazyload">
+<img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom:10px; max-height: 240px" class="lazyload">
 
 Mirage Realms is an ambitious solo project to produce a free to play MMORPG for different platforms. [[Android](https://play.google.com/store/apps/details?id=com.foxcake.mirage.android) / [Desktop](https://www.miragerealms.co.uk/devblog/play/)]
 


### PR DESCRIPTION
Obviously this page needs improvement behind the scenes, but this should hold in the mean time.

By removing instances of `max-width`, the three affected images will fall back to the default max width of 100% and thereby no longer exceed the device width on mobile. This has no impact on desktop because they're still constrained by `max-height`.