### PR TITLE
AdoptOpenJDK -> Adoptium

### DIFF
--- a/_pages/dev/-tutorials/setup.md
+++ b/_pages/dev/-tutorials/setup.md
@@ -34,7 +34,7 @@ For newcomers wanting to not only target desktop, but mobile platforms as well, 
 - For iOS: [RoboVM OSS IntelliJ plugin](http://robovm.mobidevelop.com)
 
 ## (2.) IDEA
-- JDK 8+: there are different distributions, but [Adopt OpenJDK](https://adoptopenjdk.net) should fit your needs
+- JDK 8+: there are different distributions, but [Adoptium](https://adoptium.net/) should fit your needs
 
    At the moment, libGDX projects do <u>not</u> work with JDK 16, as Gretty does not yet support Gradle 7. As a consequence, you are advised to use **JDK 8-15**!
    {: .notice}
@@ -43,7 +43,7 @@ For newcomers wanting to not only target desktop, but mobile platforms as well, 
 - For iOS: [RoboVM OSS IntelliJ plugin](http://robovm.mobidevelop.com)
 
 ## (3.) Eclipse
-- JDK 8+: there are different distributions, but [Adopt OpenJDK](https://adoptopenjdk.net) should fit your needs
+- JDK 8+: there are different distributions, but [Adoptium](https://adoptium.net/) should fit your needs
 
    At the moment, libGDX projects do <u>not</u> work with JDK 16, as Gretty does not yet support Gradle 7. As a consequence, you are advised to use **JDK 8-15**!
    {: .notice}
@@ -55,7 +55,7 @@ For newcomers wanting to not only target desktop, but mobile platforms as well, 
 As Netbeans is not commonly used in the libGDX community, it may prove difficult to get any help if IDE-specific issues arise.
 {: .notice--info}
 
-- JDK 8+: there are different distributions, but [Adopt OpenJDK](https://adoptopenjdk.net) should fit your needs
+- JDK 8+: there are different distributions, but [Adoptium](https://adoptium.net/) should fit your needs
 
     At the moment, libGDX projects do <u>not</u> work with JDK 16, as Gretty does not yet support Gradle 7. As a consequence, you are advised to use **JDK 8-15**!
    {: .notice}
@@ -67,7 +67,7 @@ As Netbeans is not commonly used in the libGDX community, it may prove difficult
 It is also possible to develop libGDX applications entirely without any IDE, just using a simple editor like Notepad or [Vim](https://www.vim.org). This is **not** recommended, because IDEs provide some very convenient features, such as code completion and error checking. However, if you insist on doing so: libGDX applications are Gradle applications, so they can be built and executed via the commandline.
 {: .notice--info}
 
-- JDK 8+: there are different distributions, but [Adopt OpenJDK](https://adoptopenjdk.net) should fit your needs
+- JDK 8+: there are different distributions, but [Adoptium](https://adoptium.net/) should fit your needs
 
    At the moment, libGDX projects do <u>not</u> work with JDK 16, as Gretty does not yet support Gradle 7. As a consequence, you are advised to use **JDK 8-15**!
    {: .notice}


### PR DESCRIPTION
It is no longer possible, at least as far as I can see, to download JDKs from adoptopenjdk.net. It has now moved to adoptium.net.