### PR TITLE
Fix jam schedule newlines

### DIFF
--- a/_pages/community/jams.md
+++ b/_pages/community/jams.md
@@ -20,24 +20,24 @@ toc_sticky: false
 If you want to stay up to date – join the official [libGDX Discord](/community/discord/)!
 
 ## March 2022
-Jam Suggestions: 13th-15th 
-Jam Voting: 17th-19th 
-Jam: 20th-26th 
+Jam Suggestions: 13th-15th  
+Jam Voting: 17th-19th  
+Jam: 20th-26th
 
 ## June
-Jam Suggestions: 12th-14th 
-Jam Voting: 16th-18th 
-Jam: 19th-25th 
+Jam Suggestions: 12th-14th  
+Jam Voting: 16th-18th  
+Jam: 19th-25th
 
 ## September 2022
-Jam Suggestions: 11th-13th 
-Jam Voting: 15th-17th 
-Jam: 18th-24th 
+Jam Suggestions: 11th-13th  
+Jam Voting: 15th-17th  
+Jam: 18th-24th
 
 ## December 2022
-Jam Suggestions: 4th-6th 
-Jam Voting: 8th-10th 
-Jam: 11th-17th 
+Jam Suggestions: 4th-6th  
+Jam Voting: 8th-10th  
+Jam: 11th-17th
 
 <br/>
 

--- a/_posts/2022/2022-01-20-2022-jam-dates.md
+++ b/_posts/2022/2022-01-20-2022-jam-dates.md
@@ -22,21 +22,21 @@ Hey everybody!
 Today we'd like to announce our schedule for 2022's libGDX jams. If you want to stay up to date with any future developments, be sure to join the official [libGDX Discord](/community/discord/)! Further information about the jams – including the rules – can, as always, be found [here](/community/jams/#rules).
 
 ### March 2022
-Jam Suggestions: 13th-15th 
-Jam Voting: 17th-19th 
-Jam: 20th-26th 
+Jam Suggestions: 13th-15th  
+Jam Voting: 17th-19th  
+Jam: 20th-26th
 
 ### June
-Jam Suggestions: 12th-14th 
-Jam Voting: 16th-18th 
-Jam: 19th-25th 
+Jam Suggestions: 12th-14th  
+Jam Voting: 16th-18th  
+Jam: 19th-25th
 
 ### September 2022
-Jam Suggestions: 11th-13th 
-Jam Voting: 15th-17th 
-Jam: 18th-24th 
+Jam Suggestions: 11th-13th  
+Jam Voting: 15th-17th  
+Jam: 18th-24th
 
 ### December 2022
-Jam Suggestions: 4th-6th 
-Jam Voting: 8th-10th 
-Jam: 11th-17th 
+Jam Suggestions: 4th-6th  
+Jam Voting: 8th-10th  
+Jam: 11th-17th


### PR DESCRIPTION
The newlines were broken on the jam pages, resulting in "Jam Suggestions: 13th-15th Jam Voting: 17th-19th Jam: 20th-26th" being one long line. Markdown requires two spaces at the end of a line.

Alternatively, you could use bullet points like with last year's jam schedule post. Also interesting that these two pages have different `overlay_filter` values - maybe that helps distinguish the pages from one another very slightly. I don't have a strong opinion on anything in this second paragraph.