### PR TITLE
External Tutorials: Updating links and cosmetics/semantics

### DIFF
--- a/wiki/articles/external-tutorials.md
+++ b/wiki/articles/external-tutorials.md
@@ -5,65 +5,65 @@ This page gives a list of some **external tutorials**, if our wiki here isn't en
 
 *Preliminary note:* Given the nature of this page's content it is likely that some of the links displayed here might become offline or even change. If you spot some broken link or wrong information please feel free to edit this page so we can keep our wiki as up-to-date as possible. Thank you.
 
-# General Tutorial Websites #
+## General tutorial websites
 These are webpages where individuals or companies write about their experience with libGDX from a technical perspective. Some of the tutorials present in these pages are also referenced below in more topic specific sections but if you're just looking to some websites where people talk about their general experiences with libGDX you should start here.
 
-**Some one-page tutorials for beginners:**
+### Some one-page tutorials for beginners
 - [Simple breakout game – focused on beginners with no prior game dev experience](https://colourtann.github.io/HelloLibgdx/)
 - [Sprite Sheets & Physics with Box2d – Tutorial by Code and Web](https://www.codeandweb.com/texturepacker/tutorials/libgdx-physics)
-- [libGDX code samples (see the sidebar)](http://libgdx.info/)
-- [Some blog posts regarding libGDX – by Rotating Canvas](http://rotatingcanvas.com/category/tutorials/)
+- [libGDX code samples (see the sidebar)](https://libgdxinfo.wordpress.com/)
+- [Some blog posts regarding libGDX – by Rotating Canvas](https://rotatingcanvas.com/category/tutorials/)
 
-**Complete tutorial series:**
+### Complete tutorial series
 - [GameDevelopment.blog – 17 parts](https://www.gamedevelopment.blog/full-libgdx-game-tutorial-flgt-home/) (2017)
-- [Flappy Bird Remake - 12 parts](http://www.kilobolt.com/zombie-bird-tutorial-flappy-bird-remake.html) (2016?)
-- [GameFromScratch.com - 17 parts](http://www.gamefromscratch.com/page/LibGDX-Tutorial-series.aspx) (2014)
+- [Flappy Bird Remake – 12 parts](http://www.kilobolt.com/zombie-bird-tutorial-flappy-bird-remake.html) (2016?)
+- [GameFromScratch.com – 17 parts](https://gamefromscratch.com/libgdx-tutorial-series/) (2014)
 
-**Video tutorials:**
-- [By Brandon Grasely – 12 parts](https://www.youtube.com/watch?v=DK1sGc4rOT4&list=PLfd-5Q3Fwq0WKrkEKw12nqpfER3MG5_Wi) (2020)
+### Video tutorials
+- [By Brandon Grasely – 12 parts](https://www.youtube.com/playlist?list=PLfd-5Q3Fwq0WKrkEKw12nqpfER3MG5_Wi) (2020)
 - [By Coldwild Games – 27 parts](https://www.youtube.com/playlist?list=PLMpInWzi-D9Jf_Co---0L7K-MNDNf2FuO) (2017)
 - [Asteroid game – by ForeignGuyMike](https://www.youtube.com/playlist?list=PL-2t7SM0vDfeZUKeM7Jm4U9utHwFS1N-C) (2014)
 - [By dermetfan – 25 parts](https://www.youtube.com/playlist?list=PLXY8okVWvwZ0JOwHiH1TntAdq-UDPnC2L) (2013)
 
-# Topic Specific Tutorials #
+## Topic-specific tutorials
 ### AdMob integration for libGDX Android projects ###
-* [norakomi.com](http://norakomi.com/tutorial_admob_introduction.php)
+* [norakomi.com](https://web.archive.org/web/20200807000743/http://norakomi.com/tutorial_admob_introduction.php)
 
-### Lighting ###
+### Lighting
  * [Normal Mapping](https://web.archive.org/web/20200508234246/http://www.java-gaming.org/topics/glsl-using-normal-maps-to-illuminate-a-2d-texture-libgdx/27516/view.html)
  * [Shadow Mapping](https://www.microbasic.net/tutorials/shadow-mapping/Full.html)
 
-### UI with Scene2D ###
+### UI with Scene2D
 * [From the Ground Up Series by raeleus](https://github.com/raeleus/skin-composer/wiki/From-the-Ground-Up:-Scene2D.UI-Tutorials) (recommended!)
-* [javagamexyz](http://javagamexyz.blogspot.pt/2013/04/user-interface-menus-using-libgdx.html)
-* [Video series by dermetfan](http://www.youtube.com/playlist?list=PLXY8okVWvwZ0Inrp5YMmYEaoh1FBXBJ1J)
+* [javagamexyz](https://javagamexyz.blogspot.pt/2013/04/user-interface-menus-using-libgdx.html)
+* [Video series by dermetfan](https://www.youtube.com/playlist?list=PLXY8okVWvwZ0Inrp5YMmYEaoh1FBXBJ1J)
 
-### Performance Related ###
-* [Image Formats: PNG, JPEG, or GIF?](http://gamedev.stackexchange.com/questions/48304/which-image-format-is-more-memory-efficient-png-jpeg-or-gif)
+### Performance-related
+* [Image Formats: PNG, JPEG, or GIF?](https://gamedev.stackexchange.com/questions/48304/which-image-format-is-more-memory-efficient-png-jpeg-or-gif)
 * [A splash screen on application startup (example)](https://github.com/raeleus/LibGDX-SplashScreen-Example)
-* [Showing a splash screen while doing heavy processing](http://duckseason.mobi/heavy-background-processes-libgdxwhile-showing-splash-screen/)
+* [Showing a splash screen while doing heavy processing](https://duckseason.mobi/heavy-background-processes-libgdxwhile-showing-splash-screen/)
 
-### Shaders ###
+### Shaders
 * [Matt DesLauriers has a very nice introduction to GLSL shaders](https://github.com/mattdesl/lwjgl-basics/wiki/Shaders) (both libGDX specific and in general)
 * [Video series by dermetfan](https://www.youtube.com/playlist?list=PLXY8okVWvwZ1_aaMnBU5HF4UP3hHL60Vy)
 * Online Shader Tools, which let you play with WebGL (provided your browser supports it) and see the code behind it:
    * https://www.shadertoy.com/
-   * http://glslsandbox.com
+   * https://glslsandbox.com
 
-### Tile based games ###
+### Tile-based games
 * [Video tutorial series by dermetfan](https://www.youtube.com/playlist?list=PLXY8okVWvwZ0qmqSBhOtqYRjzWtUCWylb)
-   * [gdx-tiled-preprocessor video tutorial](http://youtu.be/q5D-TzlCRPM) (Warning: the gdx-tiled-preprocessor was merged into gdx-tools)
+   * [gdx-tiled-preprocessor video tutorial](https://www.youtube.com/watch?v=q5D-TzlCRPM) (Warning: the gdx-tiled-preprocessor was merged into gdx-tools)
 
-# Some simple open-source projects for reference #
+## Some simple open-source projects for reference
 These are some open-source projects found on the web that use libGDX and can be used as reference. This list is intentionally kept as clean and interesting as possible (you won't see repeated projects nor _Hello-World kind-of-games_ here).
 * [Fire and Ice](https://github.com/lyze237/FireAndIce) (uses tile maps)
 * [On Guard](https://github.com/lyze237/On-Guard) (uses tile maps)
 * [Lendigastel](https://github.com/mgsx-dev/dl9) (3D; uses [gdx-gltf](https://github.com/mgsx-dev/gdx-gltf))
-* [libGDX vs Ray3K](https://github.com/raeleus/libgdx-jam-june-2020) (local multiplayer Smash Bros clone)
+* [libGDX vs Ray3K](https://github.com/raeleus/libgdx-jam-june-2020) (local multiplayer Smash Bros. clone)
 * [Super Spineboy](https://github.com/EsotericSoftware/spine-superspineboy) (a platformer using [Spine](http://www.esotericsoftware.com))
 * [Klooni 1010!](https://github.com/LonamiWebs/Klooni1010) (puzzle game based on the original 1010!)
 * [TDGalaxy](https://github.com/TheLogicMaster/Tower-Defense-Galaxy) (modular 3D tower defense game)
 * [bombergame](https://github.com/mcol/bombergame)
 * [martianrun](https://github.com/wmora/martianrun) (2D running game; uses AdMob and Google Play Game Services)
-* [GdxCombat](https://github.com/gamedevpl/GdxCombat) (2D mortal kombat like game)
+* [GdxCombat](https://github.com/gamedevpl/GdxCombat) (2D Mortal Kombat-like game)
 * [rpgboss-editor](https://github.com/rpgboss/rpgboss)


### PR DESCRIPTION
I would like an anchor link to the video tutorials section. That's all I came here for.

Headings have only been converted from title case to sentence case to follow the same style as their subheadings. If this is a matter anyone feels strongly about, it can be added to the style guide. Nothing here affects existing anchor links.