### PR TITLE
Added docker file for local testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+jekyll:
+  image: jekyll/jekyll
+  command: jekyll serve --watch --incremental --force_polling --verbose --livereload
+  ports:
+    - 4000:4000
+  volumes:
+    - .:/srv/jekyll


### PR DESCRIPTION
We all know that jekyll is super annoying to setup locally, especially on windows. 

Doing it via docker is quite simple however, therefore this PR adds a simple docker compose file which starts jekyll in serve mode.

Now all you have to do to start a local test server, is to install docker and run `docker-compose up`!

(Jekyll serve starts a local web server which constantly updates changed files (after ~20 couple seconds).)