### PR TITLE
Move sidebar after wiki content

### DIFF
--- a/_layouts/wiki.html
+++ b/_layouts/wiki.html
@@ -14,6 +14,9 @@ layout: default_wiki
   <article class="page h-entry" itemscope itemtype="https://schema.org/CreativeWork">
     <div class="page__inner-wrap">
       <section class="page__content e-content markdown-body" itemprop="text">
+      
+          {{ content }}
+      
           <aside class="sidebar__right">
             <div class="toc">
               <div class="wiki_toc__menu">
@@ -27,8 +30,6 @@ layout: default_wiki
               </div>
             </div>
           </aside>
-
-        {{ content }}
 
         <div class="copyright_footer">
           <p style="font-size: 13px;margin-bottom: 0px !important;">


### PR DESCRIPTION
Currently on the wiki, the sidebar, while visually on the right, comes before the main content. This is frustrating if you want to Ctrl+F to a point on the page or Tab through stuff, as the sidebar gets priority. Here I've swapped them around, which doesn't seem to have broken anything.