### PR TITLE
Update command for running gdx-setup to nightly version

### DIFF
--- a/wiki/start/project-generation.md
+++ b/wiki/start/project-generation.md
@@ -16,7 +16,7 @@ To setup your first project and download the necessary dependencies, libGDX offe
     <a href="https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar" class="btn btn--success">Nightly Version</a>-->
     <a href="https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar" class="btn btn--success">Download</a>
 
-2. Double-click the downloaded file. If this doesn't work, open your command line tool, go to the download folder and run <br>`java -jar ./gdx-setup_latest.jar`
+2. Double-click the downloaded file. If this doesn't work, open your command line tool, go to the download folder and run <br><!--`java -jar ./gdx-setup_latest.jar`-->`java -jar ./gdx-setup.jar`
 
 This will open the following setup that will allow you to generate your project:
 

--- a/wiki/start/project-generation.md
+++ b/wiki/start/project-generation.md
@@ -16,7 +16,7 @@ To setup your first project and download the necessary dependencies, libGDX offe
     <a href="https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar" class="btn btn--success">Nightly Version</a>-->
     <a href="https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-runnables/gdx-setup.jar" class="btn btn--success">Download</a>
 
-2. Double-click the downloaded file. If this doesn't work, open your command line tool, go to the download folder and run <br><!--`java -jar ./gdx-setup_latest.jar`-->`java -jar ./gdx-setup.jar`
+2. Double-click the downloaded file. If this doesn't work, open your command line tool, go to the download folder and run <br><!--`java -jar gdx-setup_latest.jar`-->`java -jar gdx-setup.jar`
 
 This will open the following setup that will allow you to generate your project:
 


### PR DESCRIPTION
307791b9e2af9a55ee91175e49c64426d71b4009 is missing a change to the command for running the gdx-setup JAR, as the nightly version has a different filename from the stable version.

While I was here, I've also removed the `./` part of the command, since the argument already assumes the filepath is from the current directory. If there's some reason for this, just add it back of course.