### PR TITLE
Remove second underline from wiki navigation

### DIFF
--- a/_sass/wiki.scss
+++ b/_sass/wiki.scss
@@ -67,6 +67,10 @@ article.page {
   }
 }
 
+.visible-links a:hover {
+  text-decoration: none;
+}
+
 // WIKI NAVBAR AT THE SIDE
 @media (prefers-color-scheme: light) {
   .toc {

--- a/_sass/wiki.scss
+++ b/_sass/wiki.scss
@@ -67,7 +67,7 @@ article.page {
   }
 }
 
-.visible-links a:hover {
+.greedy-nav a:hover {
   text-decoration: none;
 }
 


### PR DESCRIPTION
The default underline placed by the browser looked a bit odd in conjunction with the custom underline and didn't match the rest of the website.

![](https://user-images.githubusercontent.com/60154347/157509251-7ed98ba3-74aa-42c2-a29a-0079213db494.png)