### PR TITLE
Fixed June jam to say June 2022 to Match the rest.

### DIFF
--- a/_pages/community/jams.md
+++ b/_pages/community/jams.md
@@ -19,7 +19,7 @@ toc_sticky: false
 # Upcoming
 If you want to stay up to date – join the official [libGDX Discord](/community/discord/)!
 
-## June
+## June 2022
 Jam Suggestions: 12th-14th  
 Jam Voting: 16th-18th  
 Jam: 19th-25th

--- a/_posts/2022/2022-01-20-2022-jam-dates.md
+++ b/_posts/2022/2022-01-20-2022-jam-dates.md
@@ -26,7 +26,7 @@ Today we'd like to announce our schedule for 2022's libGDX jams. If you want to 
 - Jam Voting: 17th-19th  
 - Jam: 20th-26th
 
-### June
+### June 2022
 - Jam Suggestions: 12th-14th  
 - Jam Voting: 16th-18th  
 - Jam: 19th-25th


### PR DESCRIPTION
For some reason the June jam section was just titled June. Instead of Month + Year, like every other section. So I fixed it.