### PR TITLE
Add `webrick` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "jekyll", '~> 3.9.0', group: :jekyll_plugins
 
 gem "tzinfo-data"
+gem "webrick", "~> 1.7" # needed for Ruby 3.x
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 # If you have any plugins, put them here!
@@ -21,5 +22,3 @@ group :jekyll_plugins do
   gem "jekyll-github-metadata"
 #  gem "jekyll-last-modified-at"
 end
-
-gem "webrick", "~> 1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,5 @@ group :jekyll_plugins do
   gem "jekyll-github-metadata"
 #  gem "jekyll-last-modified-at"
 end
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
 The `webrick` gem was removed from the standard library in Ruby 3. I dunno what this all means, but I ended up at [https://stackoverflow.com/q/65617143](https://stackoverflow.com/questions/65617143/cannot-load-such-file-webrick-httputils) and doing the `bundle add webrick` thing fixed it. If there's a better solution, obviously do that instead.