### PR TITLE
Update masking.md

### DIFF
--- a/wiki/graphics/2d/masking.md
+++ b/wiki/graphics/2d/masking.md
@@ -404,6 +404,8 @@ public void render() {
 
 ![Masked sprite and original sprites](https://imgur.com/Lmqecgk.png)
 
+This example renders directly to the screen buffer, but it's recommended that you render to a [FrameBuffer  object](https://libgdx.com/wiki/graphics/opengl-utils/frame-buffer-objects) if you intend to draw anything underneath your masked elements.
+
 ## 5. Masking using Pixmaps (Shapes or Textures)
 
 This technique allows the mask to be any image or shape and takes the alpha channel into account. This time we'll be using the libGDX’s Pixmap class.

--- a/wiki/graphics/2d/masking.md
+++ b/wiki/graphics/2d/masking.md
@@ -404,7 +404,7 @@ public void render() {
 
 ![Masked sprite and original sprites](https://imgur.com/Lmqecgk.png)
 
-This example renders directly to the screen buffer, but it's recommended that you render to a [FrameBuffer  object](https://libgdx.com/wiki/graphics/opengl-utils/frame-buffer-objects) if you intend to draw anything underneath your masked elements.
+This example renders directly to the screen buffer, but it's recommended that you render to a [FrameBuffer  object](/wiki/graphics/opengl-utils/frame-buffer-objects) if you intend to draw anything underneath your masked elements.
 
 ## 5. Masking using Pixmaps (Shapes or Textures)
 


### PR DESCRIPTION
Per a user request, I am adding a line to the Masking wiki page to clear up some confusion regarding artifacts created when drawing underneath a masked image using the blending function technique.