### PR TITLE
Move March Jam to Past section

### DIFF
--- a/_pages/community/jams.md
+++ b/_pages/community/jams.md
@@ -19,11 +19,6 @@ toc_sticky: false
 # Upcoming
 If you want to stay up to date – join the official [libGDX Discord](/community/discord/)!
 
-## March 2023
-Jam Suggestions: 12th – 14th  
-Jam Voting: 16th – 18th  
-Jam: 19th – 25th
-
 ## June 2023
 Jam Suggestions: 11th – 13th  
 Jam Voting: 15th – 17th  
@@ -56,6 +51,7 @@ We encourage camaraderie, teamwork, and good sportsmanship with a side of well-i
 <br/>
 
 # Past Jams
+* [Pixel Wars](https://itch.io/jam/libgdx-jam-24) (March 2023)
 * [DYSTOPIAN CHRISTMAS](https://itch.io/jam/libgdx-jam-23) (December 2022)
 * [Post Apocalyptic](https://itch.io/jam/libgdx-jam-22) (September 2022)
 * [Floating Cities](https://itch.io/jam/libgdx-jam-21) (June 2022)


### PR DESCRIPTION
Updates Jam page to move March Jam into Past Jams section. I made the edit using Github web editor.