### PR TITLE
Update gradle instructions to use non-deprecated functions

### DIFF
--- a/wiki/jvm-langs/using-libgdx-with-kotlin.md
+++ b/wiki/jvm-langs/using-libgdx-with-kotlin.md
@@ -71,7 +71,7 @@ Add Kotlin’s stdlib to your core project's dependencies list:
 
 ```Groovy
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 ```
 
@@ -79,7 +79,7 @@ If you intend to use Kotlin’s reflection capabilities as well, add the respect
 
 ```Kotlin
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }
 ```
 
@@ -89,7 +89,7 @@ If you made Intellij automatically configure `build.gradle` for you, and chose K
 
 ```Kotlin
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
 }
 ```
 


### PR DESCRIPTION
Per https://stackoverflow.com/a/66910991:

> Note that the compile, runtime, testCompile, and testRuntime configurations introduced by the Java plugin have been deprecated since [Gradle 4.10](https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) ([Aug 27, 2018](https://gradle.org/releases/)), and were finally removed in [Gradle 7.0](https://docs.gradle.org/7.0/userguide/java_library_plugin.html#sec:java_library_configurations_graph) ([Apr 9, 2021](https://gradle.org/releases/)).
>
> The aforementioned configurations should be replaced by implementation, runtimeOnly, testImplementation, and testRuntimeOnly, respectively.