### PR TITLE
Update http to https in urls in networking article

### DIFF
--- a/wiki/networking.md
+++ b/wiki/networking.md
@@ -34,14 +34,14 @@ ServerSocket server = Gdx.net.newServerSocket(Protocol protocol, int port, Serve
 To send an HTTP Request use this:
 ```java
 HttpRequestBuilder requestBuilder = new HttpRequestBuilder();
-HttpRequest httpRequest = requestBuilder.newRequest().method(HttpMethods.GET).url("http://www.google.de").build();
+HttpRequest httpRequest = requestBuilder.newRequest().method(HttpMethods.GET).url("https://www.google.de").build();
 Gdx.net.sendHttpRequest(httpRequest, httpResponseListener);
 ```
 
 To send a GET HTTP Request with arguments use this:
 ```java
 HttpRequestBuilder requestBuilder = new HttpRequestBuilder();
-HttpRequest httpRequest = requestBuilder.newRequest().method(HttpMethods.GET).url("http://www.google.de").content("q=libgdx&example=example").build();
+HttpRequest httpRequest = requestBuilder.newRequest().method(HttpMethods.GET).url("https://www.google.de").content("q=libgdx&example=example").build();
 Gdx.net.sendHttpRequest(httpRequest, httpResponseListener);
 ```
 To open the system browser use this:


### PR DESCRIPTION
This is just a quick PR to update the google links in the networking article to https to showcase that the http request method also supports https://