### PR TITLE
Correct Background Color Description in "A Simple Game" Tutorial

### DIFF
--- a/wiki/start/a-simple-game.md
+++ b/wiki/start/a-simple-game.md
@@ -217,7 +217,7 @@ Next we load the sound effect and the background music. libGDX differentiates be
 
 Loading of a `Sound` or `Music` instance is done via `Gdx.audio.newSound()` and `Gdx.audio.newMusic()`. Both of these methods take a `FileHandle`, just like the `Texture` constructor.
 
-At the end of the `create()` method we also tell the `Music` instance to loop and start playback immediately. If you run the application you'll see a nice pink background and hear the rain fall.
+At the end of the `create()` method we also tell the `Music` instance to loop and start playback immediately. If you run the application you'll see a nice red background and hear the rain fall.
 
 ## A Camera and a SpriteBatch
 Next up, we want to create a camera and a `SpriteBatch`. We'll use the former to ensure we can render using our target resolution of 800x480 pixels no matter what the actual screen resolution is. The `SpriteBatch` is a special class that is used to draw 2D images, like the textures we loaded.


### PR DESCRIPTION
#### Summary
This PR corrects a detail in the "A Simple Game" tutorial regarding the background color information.

#### Details
In the "A Simple Game" tutorial:

> When we run the game now, we will get the default 'game' generated by the setup app: a Badlogic Games image on a **pink** background.

However, the default game setting of the background color is red, given the code `ScreenUtils.clear(1, 0, 0, 1);` should set the color to red instead of pink.

#### Proposed Change
Update the documentation in the tutorial to state that the background color is red, instead of pink. This change will ensure accuracy and prevent any confusion for readers learning about rendering and color values in LibGDX.

Thank you for considering this update to the documentation.
