### PR TITLE
Use IntelliJ IDEA name brand consistently across the wiki

### DIFF
--- a/_pages/dev/-contributing/contributing.md
+++ b/_pages/dev/-contributing/contributing.md
@@ -33,7 +33,7 @@ Signing the CLA will allow us to use and distribute your code. This is a non-exc
 ## Formatting
 If you are working on any of the libGDX code, we require you to use our formatter. To make our life easier, we have integrated the formatter into our build system with  [Spotless](https://github.com/diffplug/spotless). This allows you to run `./gradlew spotlessApply` to format your files locally and also ensures that pull requests are formatted automatically via GitHub Actions.
 
-Alternatively, you can find the Eclipse formatter file [here](https://github.com/libgdx/libgdx/blob/master/eclipse-formatter.xml), which can also be imported into IntelliJ and Android Studio. See [here](https://blog.jetbrains.com/idea/2014/01/intellij-idea-13-importing-code-formatter-settings-from-eclipse/) for official documentation on how to do this.
+Alternatively, you can find the Eclipse formatter file [here](https://github.com/libgdx/libgdx/blob/master/eclipse-formatter.xml), which can also be imported into IntelliJ IDEA and Android Studio. See [here](https://blog.jetbrains.com/idea/2014/01/intellij-idea-13-importing-code-formatter-settings-from-eclipse/) for official documentation on how to do this.
 
 ## Code Style
 libGDX doesn't have an official coding standard, but we stand by the usual Java style, as should you.

--- a/_pages/dev/-contributing/from_source.md
+++ b/_pages/dev/-contributing/from_source.md
@@ -17,7 +17,7 @@ sidebar:
 {% include breadcrumbs.html %}
 
 # Setting the Project Up
-If you want to work on the code of libGDX itself, you need to get it set up on your local machine. For this, Android Studio is strongly recommended as IDE!
+If you want to work on the code of libGDX itself, you need to get it set up on your local machine. For this, IntelliJ IDEA/Android Studio is strongly recommended as IDE!
 
 If you want to submit code back to the project, please also take a moment to review our [guidelines](/dev/contributing/).
 
@@ -35,7 +35,7 @@ If you want to submit code back to the project, please also take a moment to rev
    ```
 4. Importing the project:
 
-    a) **Via IntelliJ/Android Studio:**
+    a) **Via IntelliJ IDEA/Android Studio:**
 
      - File -> Open -> libGDX root `build.gradle`
      - Import all projects
@@ -59,7 +59,7 @@ If you encounter any issues while setting up your development environment for li
 # Tests
 If you set everything up correctly, you can try to give the libGDX tests a go.
 
-**LWJGL/LWJGL3:** Run the `LwjglTestStart` class located in tests/gdx-tests/gdx-tests-lwjgl/src (or tests/gdx-tests/gdx-tests-lwjgl3/src respectively) by right clicking and running. You should get _assets not found_ when you try to run a test, so edit the run configuration and point it to the correct assets folder (`tests/gdx-tests-android/assets`). For IntelliJ:
+**LWJGL/LWJGL3:** Run the `LwjglTestStart` class located in tests/gdx-tests/gdx-tests-lwjgl/src (or tests/gdx-tests/gdx-tests-lwjgl3/src respectively) by right clicking and running. You should get _assets not found_ when you try to run a test, so edit the run configuration and point it to the correct assets folder (`tests/gdx-tests-android/assets`). For IntelliJ IDEA:
 
 ![](/assets/images/dev/source/0.png)
 

--- a/wiki/articles/improving-workflow-with-gradle.md
+++ b/wiki/articles/improving-workflow-with-gradle.md
@@ -8,7 +8,7 @@ title: Improving workflow with Gradle
  * [**Gradle Daemon**](#gradle-daemon)
  * [**Configuration on Demand**](#configuration-on-demand)
 * [**Removing Gradle integration from your IDE**](#how-to-remove-gradle-ide-integration-from-your-project)
- * [**Intellij IDEA**](#creating-your-idea-project)
+ * [**IntelliJ IDEA**](#creating-your-idea-project)
  * [**Eclipse**](#creating-your-eclipse-project)
 * [**libGDX without Gradle**](#libgdx-without-gradle)
 * [**Why does libGDX recommend Gradle**](#why-does-libgdx-recommend-gradle)
@@ -17,7 +17,7 @@ title: Improving workflow with Gradle
 ## Introduction
 Gradle is very powerful, and once you get used to it is a great tool to be versed in and to have in your arsenal, but when mixed with your IDE it can cause workflow problems. This varies from project to project, and from person to person; here is an example of such an issue:
 
-Having a multi-project, multi-flavour project, where you want to be running your desktop build very often to check your latest changes. Due to how Gradle works (it allows the flexibility of accessing and changing any part of the build from any part of the project), it must configure all projects in a multi-project setup before any task is executed. When you have a project with desktop only, this is usually very speedy, but when you add in an android project and a html project the setup time starts to rack up. This is especially noticeable in Intellij IDEA.
+Having a multi-project, multi-flavour project, where you want to be running your desktop build very often to check your latest changes. Due to how Gradle works (it allows the flexibility of accessing and changing any part of the build from any part of the project), it must configure all projects in a multi-project setup before any task is executed. When you have a project with desktop only, this is usually very speedy, but when you add in an android project and a html project the setup time starts to rack up. This is especially noticeable in IntelliJ IDEA.
 
 ## Tips to speed up Gradle if you still want IDE integration
 
@@ -43,7 +43,7 @@ Add the line; `org.gradle.configureondemand=true`
 
 ## How to remove Gradle IDE integration from your project
 
-_Note: This only applies for Eclipse and Intellij IDEA users_
+_Note: This only applies for Eclipse and IntelliJ IDEA users_
 
 With the project that is generated from gdx-setup.jar, the Gradle IDEA, and Gradle Eclipse plugins are applied to all projects.
 These plugins allow you to generate IDE specific files that you can then work from.

--- a/wiki/articles/maven-integration.md
+++ b/wiki/articles/maven-integration.md
@@ -123,9 +123,9 @@ mvn -Phtml install
 And browse to [http://127.0.0.1:8080/index.html](http://127.0.0.1:8080/index.html)
 
 ## IDE Integration
-Eclipse, Intellij Idea and NetBeans all support Maven projects in some form. The archetype goes to great lengths to make your libGDX project usable within Eclipse and Intellij Idea. NetBeans is unsupported at the time of writing.
+Eclipse, Intellij IDEA and NetBeans all support Maven projects in some form. The archetype goes to great lengths to make your libGDX project usable within Eclipse and Intellij IDEA. NetBeans is unsupported at the time of writing.
 
-While Maven is IDE agnostic, the plugins for GWT and Android are not. Plugins for Eclipse differ in how the interpret the Maven configuration for GWT and Android projects from those in Intellij. The following sections describe how to import a project into both IDE's after creating it using the libGDX archetype.
+While Maven is IDE agnostic, the plugins for GWT and Android are not. Plugins for Eclipse differ in how the interpret the Maven configuration for GWT and Android projects from those in Intellij IDEA. The following sections describe how to import a project into both IDE's after creating it using the libGDX archetype.
 
 ### Eclipse
 Before you can import your project, you need to install the following Eclipse plugins:
@@ -142,10 +142,10 @@ From there on you can run & debug just as you'd do if you setup your projects vi
 
 If you change anything in the assets, you need to run "mvn -Phtml package" again and refresh the html project in Eclipse.
 
-### IntelliJ Idea
-Before you start, you should make sure IntelliJ Idea knows where your Maven installation is located. Go to *File -> Settings*, and in the tree in the dialog chose Maven. Specify the directory where your Maven installation lives.
+### IntelliJ IDEA
+Before you start, you should make sure IntelliJ IDEA knows where your Maven installation is located. Go to *File -> Settings*, and in the tree in the dialog chose Maven. Specify the directory where your Maven installation lives.
 
-Once you created your project via the archetype you can import it into IntelliJ Idea. Go to *File -> Open Project*, then navigate to the root directory of the project.
+Once you created your project via the archetype you can import it into IntelliJ IDEA. Go to *File -> Open Project*, then navigate to the root directory of the project.
 
 Once the project is loaded, you have to enable the profiles. Open the Maven Project view and check the three profiles, desktop, android and HTML.
 

--- a/wiki/articles/maven-integration.md
+++ b/wiki/articles/maven-integration.md
@@ -123,9 +123,9 @@ mvn -Phtml install
 And browse to [http://127.0.0.1:8080/index.html](http://127.0.0.1:8080/index.html)
 
 ## IDE Integration
-Eclipse, Intellij IDEA and NetBeans all support Maven projects in some form. The archetype goes to great lengths to make your libGDX project usable within Eclipse and Intellij IDEA. NetBeans is unsupported at the time of writing.
+Eclipse, IntelliJ IDEA and NetBeans all support Maven projects in some form. The archetype goes to great lengths to make your libGDX project usable within Eclipse and IntelliJ IDEA. NetBeans is unsupported at the time of writing.
 
-While Maven is IDE agnostic, the plugins for GWT and Android are not. Plugins for Eclipse differ in how the interpret the Maven configuration for GWT and Android projects from those in Intellij IDEA. The following sections describe how to import a project into both IDE's after creating it using the libGDX archetype.
+While Maven is IDE agnostic, the plugins for GWT and Android are not. Plugins for Eclipse differ in how the interpret the Maven configuration for GWT and Android projects from those in IntelliJ IDEA. The following sections describe how to import a project into both IDE's after creating it using the libGDX archetype.
 
 ### Eclipse
 Before you can import your project, you need to install the following Eclipse plugins:

--- a/wiki/articles/updating-libgdx.md
+++ b/wiki/articles/updating-libgdx.md
@@ -22,7 +22,7 @@ The version you see will most certainly be higher than `1.5.2`. Once you've loca
 The next step is dependent on your IDE:
 
 * **Eclipse**: Select all your projects in the package explorer, right click, then click `Gradle -> Refresh All`. This will download the libGDX version you specified in `build.gradle` and wire up the JAR files with your projects correctly.
-* **Intellij IDEA** / **Android Studio**: will usually detect that your `build.gradle` has been updated and show a refresh button. Just click it and IDEA will update libGDX to the version you specified in `build.gradle`. Go into the Gradle tasks panel/tool view and click the refresh button. Running a task like 'builddependents' also tends to do this.
+* **IntelliJ IDEA** / **Android Studio**: will usually detect that your `build.gradle` has been updated and show a refresh button. Just click it and IDEA will update libGDX to the version you specified in `build.gradle`. Go into the Gradle tasks panel/tool view and click the refresh button. Running a task like 'builddependents' also tends to do this.
 * **Netbeans**: in the "Projects" view, right-click the top-most project node and select "Reload Project". All sub-projects will also be reloaded with the new files.
 * **Command Line**: invoking any of the tasks will usually check for changes in dependency versions and redownload anything that changed.
 

--- a/wiki/jvm-langs/using-libgdx-with-kotlin.md
+++ b/wiki/jvm-langs/using-libgdx-with-kotlin.md
@@ -83,9 +83,9 @@ dependencies {
 }
 ```
 
-#### Note for Intellij users
+#### Note for Intellij IDEA users
 
-If you made Intellij automatically configure `build.gradle` for you, and chose Kotlin 1.1 or higher version, it might add this dependency:
+If you made Intellij IDEA automatically configure `build.gradle` for you, and chose Kotlin 1.1 or higher version, it might add this dependency:
 
 ```Kotlin
 dependencies {

--- a/wiki/jvm-langs/using-libgdx-with-kotlin.md
+++ b/wiki/jvm-langs/using-libgdx-with-kotlin.md
@@ -83,9 +83,9 @@ dependencies {
 }
 ```
 
-#### Note for Intellij IDEA users
+#### Note for IntelliJ IDEA users
 
-If you made Intellij IDEA automatically configure `build.gradle` for you, and chose Kotlin 1.1 or higher version, it might add this dependency:
+If you made IntelliJ IDEA automatically configure `build.gradle` for you, and chose Kotlin 1.1 or higher version, it might add this dependency:
 
 ```Kotlin
 dependencies {

--- a/wiki/misc/getting-ready-for-libgdxjam.md
+++ b/wiki/misc/getting-ready-for-libgdxjam.md
@@ -68,7 +68,7 @@ All hail ye who are brave enough to take up on the #libGDXJam challenge, have yo
 Make sure you have decided on:
 
 * Libraries: obviously Libgdx, but... Are you using any extensions or third party libraries?
-* Programming language and IDE: Java, Kotlin, Clojure or Scala? Eclipse, Intellij IDEA, Netbeans, Sublime, Vim, Emacs?
+* Programming language and IDE: Java, Kotlin, Clojure or Scala? Eclipse, IntelliJ IDEA, Netbeans, Sublime, Vim, Emacs?
 * Graphic editors
 * Level editors
 * Sound generators and editors

--- a/wiki/misc/getting-ready-for-libgdxjam.md
+++ b/wiki/misc/getting-ready-for-libgdxjam.md
@@ -68,7 +68,7 @@ All hail ye who are brave enough to take up on the #libGDXJam challenge, have yo
 Make sure you have decided on:
 
 * Libraries: obviously Libgdx, but... Are you using any extensions or third party libraries?
-* Programming language and IDE: Java, Kotlin, Clojure or Scala? Eclipse, Intellij, Netbeans, Sublime, Vim, Emacs?
+* Programming language and IDE: Java, Kotlin, Clojure or Scala? Eclipse, Intellij IDEA, Netbeans, Sublime, Vim, Emacs?
 * Graphic editors
 * Level editors
 * Sound generators and editors

--- a/wiki/misc/google-summer-of-code-2014.md
+++ b/wiki/misc/google-summer-of-code-2014.md
@@ -258,7 +258,7 @@ This project could be done in collaboration with the Scripting Support project a
 
 **Goals**: libGDX projects are usually done with Eclipse in mind. While we support [Maven](/wiki/articles/maven-integration) and other IDEs and development environments, integration isn't as straight forward. Maven is problematic due to GWT and Android being somewhat second class citizens in that area. Also, IDE integration of Maven Android and GWT projects is lacking. In addition to IDE woes, packaging and deploying projects can be cumbersome. We'd like to develop a command line application that allows the creation of new libGDX projects, create project files for various IDEs, create POM and Gradle build files, can update dependencies automatically, can remove and add extensions, and package and deploy the application to connected devices. [Loom Engine](http://theengine.co/loom) and [Haxe NME](http://www.nme.io/developer/documentation/getting-started/) provide similar tools.
 
-**Required Skills**: Java, Maven, Gradle, Eclipse, Intellij, Netbeans
+**Required Skills**: Java, Maven, Gradle, Eclipse, IntelliJ, Netbeans
 **Links**: [Google Doc with requirements](https://docs.google.com/document/d/1yy3Q5B0K06yz_Oool1ZCtavtSvASJa56lic_5Yg1C9c/edit?usp=sharing)
 
 **Mentors**:
@@ -270,7 +270,7 @@ This project could be done in collaboration with the Scripting Support project a
 
 **Goals**: libGDX is used in production, and as such requires high robustness. One way of increasing robustness is to use static analysis tools that uncover bad practices and bugs. Applying such analysis to a code base as big as libGDX's is a challenge. Not only is the size an issue, but a gaming framework may have to rely on patterns for performance that are wrongly identified as issues by static analysis tools. For this idea, we'd like to see how static analysis tools can be exploited to increase libGDX's quality and how we could integrate them into our everyday workflow. It is expected that whatever tool is used for analysis needs to be adapted with new rules that fit for the requirements of a gaming framework.
 
-**Required Skills**: Java, Maven, Gradle, Eclipse, Intellij, Netbeans
+**Required Skills**: Java, Maven, Gradle, Eclipse, IntelliJ, Netbeans
 
 **Links**: [List of static analysis tools on Wikipedia](https://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis#Java)
 

--- a/wiki/start/import-and-running.md
+++ b/wiki/start/import-and-running.md
@@ -89,14 +89,14 @@ Right click the desktop project -> Run
    {: .notice--warning}
 4. Run the created run configuration
 
-For more information on using and configuring the RoboVM IntelliJ plugin please see the [documentation](https://mobivm.github.io).
+For more information on using and configuring the RoboVM IntelliJ IDEA plugin please see the [documentation](https://mobivm.github.io).
 
 ### In Eclipse
 - Right click the iOS RoboVM project > Run As > RoboVM runner of your choice
 
 ![](/assets/images/dev/eclipse/2.png)
 
-For more information on using and configuring the RoboVM IntelliJ plugin please see the [documentation](https://mobivm.github.io).
+For more information on using and configuring the RoboVM IntelliJ IDEA plugin please see the [documentation](https://mobivm.github.io).
 
 <br/>
 

--- a/wiki/third-party/google-play-games-services-in-libgdx.md
+++ b/wiki/third-party/google-play-games-services-in-libgdx.md
@@ -22,7 +22,7 @@ Another in-depth LibGDX-based tutorial for adding Google Play Game Services can 
 
 Latest tutorial using Android Studio can be found [here](https://chandruscm.wordpress.com/2015/12/30/how-to-setup-google-play-game-services-in-libgdx-using-android-studio/)
 
-### Intellij IDEA and Android Studio Setup
+### IntelliJ IDEA and Android Studio Setup
 
 1. Install Google Play Service and Google Play Repository using and Android SDK
 

--- a/wiki/third-party/google-play-games-services-in-libgdx.md
+++ b/wiki/third-party/google-play-games-services-in-libgdx.md
@@ -22,7 +22,7 @@ Another in-depth LibGDX-based tutorial for adding Google Play Game Services can 
 
 Latest tutorial using Android Studio can be found [here](https://chandruscm.wordpress.com/2015/12/30/how-to-setup-google-play-game-services-in-libgdx-using-android-studio/)
 
-### Intellij and Android Studio Setup
+### Intellij IDEA and Android Studio Setup
 
 1. Install Google Play Service and Google Play Repository using and Android SDK
 


### PR DESCRIPTION
Mainly I wanted to add IntelliJ IDEA as recommended IDE for Building from source (not just Android Studio) and I've taken the opportunity to rename were needed across the wiki.