### PR TITLE
Update Space Jam to Easter Egg Jam

### DIFF
--- a/_pages/community/jams.md
+++ b/_pages/community/jams.md
@@ -20,9 +20,11 @@ toc_sticky: false
 If you want to stay up to date – join the official [libGDX Discord](/community/discord/)!
 
 ## June 2024
-Special Space Jam  
-No suggestions or voting  
-Theme announced before the Jam starts  
+***Easter Egg Madness Jam***  
+Why have one Easter egg, when you can have five! Will you put one or two Easter eggs in your game or will you succumb to the madness and put all five?? You decide!  
+Easter eggs will be revealed before the Jam starts.  
+No suggestions.  
+Theme voting will be done via Discord.  
 Jam: 16th – 22nd
 
 ## September 2024


### PR DESCRIPTION
As announced at https://youtu.be/JIteHZXv8OM?t=2450 the Space Jam is no more. Text copied from the pinned schedule in #jam-chat. Unless it's an elaborate April Fool, but we're getting a bit out-of-season for that.

Consider assigning a jam staff member to update this page in a more timely manner than I ever will.