### PR TITLE
Correct link of 29th Jam

### DIFF
--- a/_posts/2024/2024-06-03-jam-june-2024.md
+++ b/_posts/2024/2024-06-03-jam-june-2024.md
@@ -12,7 +12,7 @@ author_displayname: raeleus
 categories: news
 ---
 
-With our 29th collaboration, the [libGDX Jam](/community/jams/) continues the time-honoured tradition of making awesome games using the best framework out there. We encourage camaraderie, teamwork, and good sportsmanship with a side of well-intentioned buffoonery. The general jam rules can as always be found [here](/community/jams/#rules). **To participate take a look at the official [itch.io page of the jam](https://itch.io/jam/libgdx-jam-27).** The humorous jam trailer can be found on [YouTube](https://www.youtube.com/watch?v=HA8s-PtDgKM).
+With our 29th collaboration, the [libGDX Jam](/community/jams/) continues the time-honoured tradition of making awesome games using the best framework out there. We encourage camaraderie, teamwork, and good sportsmanship with a side of well-intentioned buffoonery. The general jam rules can as always be found [here](/community/jams/#rules). **To participate take a look at the official [itch.io page of the jam](https://itch.io/jam/libgdx-jam-29).** The humorous jam trailer can be found on [YouTube](https://www.youtube.com/watch?v=HA8s-PtDgKM).
 
 Be sure to get involved with the community by joining the libGDX Discord server!
 


### PR DESCRIPTION
I'm assuming this page was modified from a template / older jam and this link was missed.