### PR TITLE
Set wiki tab size to 4

### DIFF
--- a/_sass/wiki.scss
+++ b/_sass/wiki.scss
@@ -276,6 +276,7 @@ body {
     line-height: 1.5;
     word-wrap: break-word;
     overflow-x: initial !important;
+	tab-size: 4;
 }
 
 @media (prefers-color-scheme: light) {

--- a/_sass/wiki.scss
+++ b/_sass/wiki.scss
@@ -276,7 +276,7 @@ body {
     line-height: 1.5;
     word-wrap: break-word;
     overflow-x: initial !important;
-	tab-size: 4;
+    tab-size: 4;
 }
 
 @media (prefers-color-scheme: light) {

--- a/_sass/wiki.scss
+++ b/_sass/wiki.scss
@@ -338,8 +338,8 @@ ul {
     list-style-type: disc;
     margin-block-start: 1em;
     margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
     padding-inline-start: 40px;
 }
 


### PR DESCRIPTION
Some code blocks on this wiki use tabs up to 7 indentation levels deep. Okay, there aren't many instances beyond 4 levels, and the pages with the most indentation are the worst ones, probably not even indented that deeply on purpose.

In any case, 4-wide indents are common for Java and will make these code blocks easier to read on mobile devices.