### PR TITLE
Tidy up stubs about packing atlases

### DIFF
--- a/_includes/wiki_index.md
+++ b/_includes/wiki_index.md
@@ -52,7 +52,6 @@
     * [Spritebatch, Textureregions, and Sprites](/wiki/graphics/2d/spritebatch-textureregions-and-sprites)
     * [Texture Compression](/wiki/graphics/2d/texture-compression)
     * [Tile maps](/wiki/graphics/2d/tile-maps)
-    * [Using textureatlases](/wiki/graphics/2d/using-textureatlases)
   * [3D Graphics](/wiki/graphics/3d/3d-graphics)
     * [3D animations and skinning](/wiki/graphics/3d/3d-animations-and-skinning)
     * [3D Particle Effects](/wiki/graphics/3d/3d-particle-effects)

--- a/_includes/wiki_index.md
+++ b/_includes/wiki_index.md
@@ -48,7 +48,6 @@
     * [Ninepatches](/wiki/graphics/2d/ninepatches)
     * [Orthographic camera](/wiki/graphics/2d/orthographic-camera)
     * [Packing atlases at runtime](/wiki/graphics/2d/packing-atlases-at-runtime)
-    * [Packing atlases offline](/wiki/graphics/2d/packing-atlases-offline)
     * [Pixmaps](/wiki/graphics/2d/pixmaps)
     * [Spritebatch, Textureregions, and Sprites](/wiki/graphics/2d/spritebatch-textureregions-and-sprites)
     * [Texture Compression](/wiki/graphics/2d/texture-compression)

--- a/_includes/wiki_sidebar.md
+++ b/_includes/wiki_sidebar.md
@@ -80,7 +80,6 @@
     * [Ninepatches](/wiki/graphics/2d/ninepatches)
     * [Orthographic camera](/wiki/graphics/2d/orthographic-camera)
     * [Packing atlases at runtime](/wiki/graphics/2d/packing-atlases-at-runtime)
-    * [Packing atlases offline](/wiki/graphics/2d/packing-atlases-offline)
     * [Pixmaps](/wiki/graphics/2d/pixmaps)
     * [Spritebatch, Textureregions, and Sprites](/wiki/graphics/2d/spritebatch-textureregions-and-sprites)
     * [Texture Compression](/wiki/graphics/2d/texture-compression)

--- a/_includes/wiki_sidebar.md
+++ b/_includes/wiki_sidebar.md
@@ -84,7 +84,6 @@
     * [Spritebatch, Textureregions, and Sprites](/wiki/graphics/2d/spritebatch-textureregions-and-sprites)
     * [Texture Compression](/wiki/graphics/2d/texture-compression)
     * [Tile maps](/wiki/graphics/2d/tile-maps)
-    * [Using textureatlases](/wiki/graphics/2d/using-textureatlases)
   * [3D Graphics](/wiki/graphics/3d/3d-graphics)
     * [3D animations and skinning](/wiki/graphics/3d/3d-animations-and-skinning)
     * [3D Particle Effects](/wiki/graphics/3d/3d-particle-effects)

--- a/wiki/graphics/2d/packing-atlases-at-runtime.md
+++ b/wiki/graphics/2d/packing-atlases-at-runtime.md
@@ -1,6 +1,5 @@
 ---
 title: Packing atlases at runtime
 ---
-- [Texture-packer](/wiki/tools/texture-packer)
 - [PixmapPacker](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/graphics/g2d/PixmapPacker.html) [(code)](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java)
 - The original [blog post](https://web.archive.org/web/20200928223250/https://www.badlogicgames.com/wordpress/?p=2297) detailing the use of `PixmapPacker`

--- a/wiki/graphics/2d/packing-atlases-offline.md
+++ b/wiki/graphics/2d/packing-atlases-offline.md
@@ -1,6 +1,0 @@
----
-title: Packing atlases offline
----
-Use the Texture Packer utility to packages offline (as opposed to during runtime of your libGDX program)
-
-[Texture Packer](/wiki/tools/texture-packer)

--- a/wiki/graphics/2d/using-textureatlases.md
+++ b/wiki/graphics/2d/using-textureatlases.md
@@ -1,4 +1,0 @@
----
-title: Using textureatlases
----
-See the [TexturePacker2 documentation](/wiki/tools/texture-packer#textureatlas) for more information.

--- a/wiki/tools/texture-packer.md
+++ b/wiki/tools/texture-packer.md
@@ -2,6 +2,7 @@
 title: Texture packer
 redirect_from:
   - /wiki/graphics/2d/packing-atlases-offline
+  - /wiki/graphics/2d/using-textureatlases
 ---
  * [TexturePacker](#texturepacker)
    * [Running TexturePacker](#running-texturepacker)

--- a/wiki/tools/texture-packer.md
+++ b/wiki/tools/texture-packer.md
@@ -1,5 +1,7 @@
 ---
 title: Texture packer
+redirect_from:
+  - /wiki/graphics/2d/packing-atlases-offline
 ---
  * [TexturePacker](#texturepacker)
    * [Running TexturePacker](#running-texturepacker)


### PR DESCRIPTION
These pages were never going to go anywhere.

I've also removed Texture Packer from the "Packing atlases at runtime " page since it doesn't belong there. Which leaves that as a very short page indeed but at least it serves some sort of purpose.