### PR TITLE
Fix more broken links

### DIFF
--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -146,7 +146,7 @@ Tap Wizard is an Idle Action-RPG like no other! Equip your Wizard with a loadout
 
 <div style="clear: both; width: 100%; height: 1px;"></div>
 
-## [Mirage Realms](https://www.miragerealms.co.uk/devblog/) by Liam Stewart
+## [Mirage Realms](https://www.miragerealms.co.uk/) by Liam Stewart
 <img align="left" src="https://lh3.googleusercontent.com/dE5E2CzrSoT_NLCgMGiG7oN_0XSuqUT3QPRCgT9_d0QzTXN4_Pa_FCAweFhNiyQoLYQ=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom: 10px; max-height: 240px" class="lazyload">
 
 Mirage Realms is an ambitious solo project to produce a free to play MMORPG for different platforms. [[Android](https://play.google.com/store/apps/details?id=com.foxcake.mirage.android) / [Desktop](https://www.miragerealms.co.uk/devblog/play/)]

--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -154,7 +154,7 @@ Mirage Realms is an ambitious solo project to produce a free to play MMORPG for 
 <div style="clear: both; width: 100%; height: 1px;"></div>
 
 ## [PokeMMO](https://pokemmo.eu/)
-<img align="right" src="https://pokemmo.eu/build/images/screenshot/c.f3968293.png" style="margin-left: 25px; margin-top: 17px; margin-bottom: 10px; max-height: 215px" class="lazyload">
+<img align="right" src="https://web.archive.org/web/20231101175437/https://pokemmo.com/build/images/screenshot/c.f3968293.png" style="margin-left: 25px; margin-top: 17px; margin-bottom: 10px; max-height: 215px" class="lazyload">
 
 PokeMMO, a fan-made, free-to-play MMORPG based on the Pokémon games. Welcome to a new era of online monster battles! [[Android](https://pokemmo.eu/downloads/android/) / [Desktop](https://pokemmo.eu/downloads/)]
 

--- a/_pages/showcase.md
+++ b/_pages/showcase.md
@@ -121,7 +121,7 @@ DIG DEEP and uncover the hidden story behind Deep Town and along the way discove
 ## [Let's Farm](https://www.facebook.com/letsfarmofficial) by Playday Games
 <img align="left" src="https://play-lh.googleusercontent.com/DPuKJ0C_FNTALF-m_0SL7eAdpbTOr-ETipzg2a8YFXY_kFjXv2ukgzkjF93U2eOfSdc=w460-h215-r" style="margin-right: 25px; margin-top: 17px; margin-bottom: 10px" class="lazyload">
 
-Let's Farm is one of the most popular farming games on mobile! Grow your own crops, cook delicious food, feed lovely pets and trade with farmers from all over the world! [[Android](https://play.google.com/store/apps/details?id=letsfarm.com.playday) / [iOS](https://apps.apple.com/us/app/lets-farm/id911657164)]
+Let's Farm is one of the most popular farming games on mobile! Grow your own crops, cook delicious food, feed lovely pets and trade with farmers from all over the world! [[Android](https://www.amazon.com/Playday-Games-Limited-Lets-Farm/dp/B00FFAEBAU) / [iOS](https://apps.apple.com/us/app/lets-farm/id911657164)]
 
 <div style="clear: both; width: 100%; height: 1px;"></div>
 

--- a/_posts/2021/2021-02-06-libgdx-graph.md
+++ b/_posts/2021/2021-02-06-libgdx-graph.md
@@ -14,7 +14,7 @@ categories: news
 
 <div class="notice--primary">
   <p>
-    Hey everybody! As announced in <a href="/news/2021/01/devlog_5_community_showcases">Status Report #5</a> we want to give creators of interesting community projects the opportunity to present their exciting libraries or tools on the official blog. This is the second of these <b>Community Showcases</b>, in which Gempukku Studio is going to present his <a href="https://github.com/marcinsc/libgdx-graph">libGDX-graph tool</a>!
+    Hey everybody! As announced in <a href="/news/2021/01/devlog_5_community_showcases">Status Report #5</a> we want to give creators of interesting community projects the opportunity to present their exciting libraries or tools on the official blog. This is the second of these <b>Community Showcases</b>, in which Gempukku Studio is going to present his <a href="https://github.com/MarcinSc/gdx-graph">libGDX-graph tool</a>!
   </p>
   <p>
     If you are interested in other cool community projects, be sure to check out the <a href="https://github.com/rafaskb/awesome-libgdx#readme">libGDX Awesome List</a> as well. To participate in future showcases, take a look <a href="https://github.com/libgdx/libgdx.github.io/wiki/Community-Showcases">here</a>.
@@ -106,7 +106,7 @@ for an example.
 
 # How to get started
 The project's readme, as well as Wiki available on the project page is a good way to start:
-[project's page](https://github.com/marcinsc/libgdx-graph).
+[project's page](https://github.com/MarcinSc/gdx-graph).
 
 In addition, there is a [Devlog playlist](https://www.youtube.com/playlist?list=PLqpawGIg6Qj5CvjOaCbB536z862XhjPQi)
 available on [author's YouTube channel](https://www.youtube.com/GempukkuStudio). This devlog has plenty of examples

--- a/archive/libgdxjam.com/viewEntry2e08.html
+++ b/archive/libgdxjam.com/viewEntry2e08.html
@@ -42,7 +42,7 @@
 					<div class="section-header">Links</div>
 					<div class="section-content">
 						<a href="https://github.com/bigbass1997/Light-Explosions/releases/latest" target="_blank">Jar</a><br><a href="https://github.com/bigbass1997/Light-Explosions" target="_blank">Source</a><br><a
-							href="https://cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif" target="_blank">Preview GIF</a><br>
+							href="https://web.archive.org/web/20231224082127/https://cdn.discordapp.com/attachments/416771042347057172/450346442238853120/2018-05-27_12-09-12.gif" target="_blank">Preview GIF</a><br>
 					</div>
 				</div>
 			</div>

--- a/wiki/articles/console-support.md
+++ b/wiki/articles/console-support.md
@@ -10,7 +10,7 @@ In addition, you need a custom libGDX backend with bindings for the device in qu
 
 ## Successful Examples
 There are a couple of games, which have successfully done this in the past:
-- [Orangepixel's games](https://www.orangepixel.net/category/games/), which are transpiled to C#<sup><a href="https://cdn.discordapp.com/attachments/348229413785305089/1154868391887245332/image.png">[1]</a></sup>
+- [Orangepixel's games](https://www.orangepixel.net/category/games/), which are transpiled to C#<sup><a href="https://web.archive.org/web/20231211232755/https://cdn.discordapp.com/attachments/348229413785305089/1154868391887245332/image.png">[1]</a></sup>
 - [Pathway](https://store.steampowered.com/app/546430/Pathway/), which uses a custom fork of RoboVM and a SDL backend<sup><a href="https://www.reddit.com/r/NintendoSwitch/comments/npx21u/comment/h07ls1u/">[2]</a></sup>
 - [Slay the Spire](https://store.steampowered.com/app/646570/Slay_the_Spire/), which was ported by [Sickhead Games](https://www.sickhead.com/) first to C# and then to C++<sup><a href="https://pbs.twimg.com/media/ETkH_QvXkAAD2N7?format=png">[3]</a></sup>
 

--- a/wiki/articles/external-tutorials.md
+++ b/wiki/articles/external-tutorials.md
@@ -32,7 +32,7 @@ These are webpages where individuals or companies write about their experience w
 
 ### Lighting
  * [Normal Mapping](https://web.archive.org/web/20200508234246/http://www.java-gaming.org/topics/glsl-using-normal-maps-to-illuminate-a-2d-texture-libgdx/27516/view.html)
- * [Shadow Mapping](https://www.microbasic.net/tutorials/shadow-mapping/Full.html)
+ * [Shadow Mapping](https://web.archive.org/web/20200429061153/https://www.microbasic.net/tutorials/shadow-mapping/Full.html)
 
 ### UI with Scene2D
 * [From the Ground Up Series by raeleus](https://github.com/raeleus/skin-composer/wiki/From-the-Ground-Up:-Scene2D.UI-Tutorials) (recommended!)

--- a/wiki/articles/external-tutorials.md
+++ b/wiki/articles/external-tutorials.md
@@ -17,7 +17,7 @@ These are webpages where individuals or companies write about their experience w
 
 ### Complete tutorial series
 - [GameDevelopment.blog – 17 parts](https://www.gamedevelopment.blog/full-libgdx-game-tutorial-flgt-home/) (2017)
-- [Flappy Bird Remake – 12 parts](http://www.kilobolt.com/zombie-bird-tutorial-flappy-bird-remake.html) (2016?)
+- [Flappy Bird Remake – 12 parts](https://web.archive.org/web/20140301152741/http://www.kilobolt.com/zombie-bird-tutorial-flappy-bird-remake.html) (2014)
 - [GameFromScratch.com – 17 parts](https://gamefromscratch.com/libgdx-tutorial-series/) (2014)
 
 ### Video tutorials

--- a/wiki/articles/external-tutorials.md
+++ b/wiki/articles/external-tutorials.md
@@ -66,5 +66,4 @@ These are some open-source projects found on the web that use libGDX and can be 
 * [TDGalaxy](https://github.com/TheLogicMaster/Tower-Defense-Galaxy) (modular 3D tower defense game)
 * [bombergame](https://github.com/mcol/bombergame)
 * [martianrun](https://github.com/wmora/martianrun) (2D running game; uses AdMob and Google Play Game Services)
-* [GdxCombat](https://github.com/gamedevpl/GdxCombat) (2D Mortal Kombat-like game)
 * [rpgboss-editor](https://github.com/rpgboss/rpgboss)

--- a/wiki/extensions/physics/bullet/bullet-wrapper-using-models.md
+++ b/wiki/extensions/physics/bullet/bullet-wrapper-using-models.md
@@ -60,7 +60,7 @@ To understand why this is, consider a simple box model. The physics shape of a b
 
 There are several more issues, e.g. a model typically contains more detail than would be needed for the physics. In fact, for some shapes it is possible to use a much cheaper collision detection algorithm than using the model's vertices. For example, in case of the box shape, it would be possible to use a single detection against a box, instead of a detection against the 12 triangles it is made of.
 
-There are several ways to work around these problems, ranging from approximating a model using primitive shapes to using a dedicated model or sharing vertices between visual model and physics shape. The [Bullet manual](https://github.com/erwincoumans/bullet2/blob/master/Bullet_User_Manual.pdf?raw=true)
+There are several ways to work around these problems, ranging from approximating a model using primitive shapes to using a dedicated model or sharing vertices between visual model and physics shape. The [Bullet manual](https://github.com/bulletphysics/bullet3/blob/master/docs/Bullet_User_Manual.pdf?raw=true)
 provides a decision chart to help you decide which method you should choose:
 ![images/bullet_shape_decision.png](/assets/wiki/images/bullet_shape_decision.png)
 

--- a/wiki/file-handling.md
+++ b/wiki/file-handling.md
@@ -55,7 +55,7 @@ The App external storage is initialized at game start for you to use, therefore 
 On iOS all file types are available.
 
 ### Javascript/WebGL
-A raw Javascript/WebGL application doesn't have a traditional filesystem concept. Instead, assets like images are referenced by URLs pointing to files on one or more servers. Modern browsers also support [Local Storage](http://diveintohtml5.info/storage.html) which comes close to a traditional read/write filesystem. The problem with local storage is that the storage amount available by default is fairly small, not standardized, and there no (good) way to accurately query the quota. For this reason, the preferences API is currently the only way to write local data persistently on the JS platform.
+A raw Javascript/WebGL application doesn't have a traditional filesystem concept. Instead, assets like images are referenced by URLs pointing to files on one or more servers. Modern browsers also support [Local Storage](https://web.archive.org/web/20240621005117/http://diveintohtml5.info/storage.html) which comes close to a traditional read/write filesystem. The problem with local storage is that the storage amount available by default is fairly small, not standardized, and there no (good) way to accurately query the quota. For this reason, the preferences API is currently the only way to write local data persistently on the JS platform.
 
 libGDX does some magic under the hood to provide you with a read-only filesystem abstraction.
 

--- a/wiki/graphics/2d/2d-particleeffects.md
+++ b/wiki/graphics/2d/2d-particleeffects.md
@@ -156,8 +156,8 @@ batch.end();
 
 
   * [Particle Effect Example on LibGDX.info](https://libgdxinfo.wordpress.com/particleeffect/)
-  * [source](https://bitbucket.org/dermetfan/somelibgdxtests/src/207cfc0a6123b48200d5cf721df222cbe7faf1be/src/net/dermetfan/someLibgdxTests/screens/ParticleEffectsTutorial.java?at=default) of the video
-  * [source](https://bitbucket.org/dermetfan/somelibgdxtests/src/4582a1bf94bded4f30df47b9195d1ae14728b847/src/net/dermetfan/someLibgdxTests/screens/ParticleEffectsTutorial.java?at=default) of the video using [pooling](https://www.youtube.com/watch?v=3OwIiELYa70)
+  * [source](https://hg.sr.ht/~dermetfan/somelibgdxtests/browse/core/src/net/dermetfan/someLibgdxTests/screens/ParticleEffectsTutorial.java) of the video
+  * [source](https://hg.sr.ht/~dermetfan/somelibgdxtests/browse/core/src/net/dermetfan/someLibgdxTests/screens/PoolingTutorial.java) of the video using [pooling](https://www.youtube.com/watch?v=3OwIiELYa70)
 
 <a href="https://www.youtube.com/watch?feature=player_embedded&v=LCLa-rgR_MA
 " target="_blank"><img src="http://img.youtube.com/vi/LCLa-rgR_MA/0.jpg"

--- a/wiki/graphics/2d/scene2d/skin.md
+++ b/wiki/graphics/2d/scene2d/skin.md
@@ -171,7 +171,7 @@ Note that order is important. A resource must be declared in the JSON above wher
 
 Skin files from the [libGDX tests](https://github.com/libgdx/libgdx/tree/master/tests/gdx-tests-android/assets/data) can be used as a starting point: uiskin.png, uiskin.atlas, uiskin.json, and default.fnt.
 
-Loading and configuring a freetype font via the skin json file requires some additional steps. Either use [Scene Composer](https://github.com/raeleus/skin-composer/wiki/Creating-FreeType-Fonts#using-a-custom-serializer) or a library like [freetype-skin](https://github.com/acanthite/freetype-skin).
+Loading and configuring a freetype font via the skin json file requires some additional steps. [Scene Composer](https://github.com/raeleus/skin-composer/wiki/Creating-FreeType-Fonts#using-a-custom-serializer) can help.
 
 ### Color
 

--- a/wiki/graphics/2d/tile-maps.md
+++ b/wiki/graphics/2d/tile-maps.md
@@ -3,7 +3,7 @@ title: Tile maps
 ---
 # Maps
 
-libGDX features a generic maps API. All map related classes can be found in the [com.badlogic.gdx.maps](https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/maps/package-use.html) [(code)](https://github.com/libgdx/libgdx/tree/master/gdx/src/com/badlogic/gdx/maps) package. The root package contains the base classes, sub-packages contain specialized implementations for tile maps and other forms of maps.
+libGDX features a generic maps API. All map related classes can be found in the [com.badlogic.gdx.maps](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/maps/package-use.html) [(code)](https://github.com/libgdx/libgdx/tree/master/gdx/src/com/badlogic/gdx/maps) package. The root package contains the base classes, sub-packages contain specialized implementations for tile maps and other forms of maps.
 
 ## Base Classes
 The set of base classes is meant to be generic so we can support not only tiled maps, but any 2D map format.

--- a/wiki/html5-backend-and-gwt-specifics.md
+++ b/wiki/html5-backend-and-gwt-specifics.md
@@ -180,6 +180,6 @@ The implementation the official HTML5 backend uses has some other restrictions, 
 
 [How to speed up GWT compilation](https://www.gamefromscratch.com/post/2013/10/07/Speeding-up-GWT-compilation-speeds-in-a-LibGDX-project.aspx)
 
-[Building libGDX from source and adding new files to gdx.gwt.xml](/wiki/misc/local-libgdx-package-use-with-gwt)
+[Contributing to libGDX and adding new files to gdx.gwt.xml](/dev/contributing/#considerations-for-gwt-compatibility)
 
 [HTML5 - GWT Explained on YouTube](https://www.youtube.com/watch?v=I_85usDvJvQ)

--- a/wiki/third-party/google-play-games-services-in-libgdx.md
+++ b/wiki/third-party/google-play-games-services-in-libgdx.md
@@ -14,7 +14,7 @@ Follow the readme and the project's wiki to integrate GPGS and other game servic
 
 The following article describes the manual integration in your project without using the library.
 
-A [Super Jumper](https://github.com/libgdx/libgdx-demo-superjumper) based example that makes use of Leaderboards and Achievements is available to download from [Google Play](https://play.google.com/store/apps/details?id=com.theinvader360.tutorial.libgdx.gameservices).
+A [Super Jumper](https://github.com/libgdx/libgdx-demo-superjumper) based example that makes use of Leaderboards and Achievements.
 
 The project is freely available on [GitHub](https://github.com/TheInvader360/libgdx-gameservices-tutorial), and a companion tutorial is available [here](https://theinvader360.blogspot.co.uk/2013/10/google-play-game-services-tutorial-example.html).
 


### PR DESCRIPTION
Can you believe I haven't fixed any broken links since 2022? It's time.

I don't want this website to fill up with Archive.org links any more than you do. But it's the best stop-gap we have.

Most of this is from what deadlinkchecker.com would show for free. Xenu's Link Sleuth got the last one but not all websites want to serve it.