### PR TITLE
Remove Prev/Next buttons

### DIFF
--- a/wiki/input/accelerometer.md
+++ b/wiki/input/accelerometer.md
@@ -59,5 +59,3 @@ Matrix4 matrix = new Matrix4();
 Gdx.input.getRotationMatrix(matrix.val);
 // use the matrix, Luke
 ```
-
-[Prev](/wiki/input/simple-text-input) | [Next](/wiki/input/compass)

--- a/wiki/input/back-and-menu-key-catching.md
+++ b/wiki/input/back-and-menu-key-catching.md
@@ -29,5 +29,3 @@ Gdx.input.setCatchKey(Input.Keys.MENU, true);
 ```
 
 There might be other keys to catch as well. You should catch all keys used to control your game to tell the operating system to prevent triggering behaviour outside your apps. This could affect media control keys on Android TV, and some general keys if you target HTML5 as well (see [HTML 5 specifics article](/wiki/html5-backend-and-gwt-specifics#preventing-keys-from-triggering-scrolling-and-other-browser-functions) for more information)
-
-[Prev](/wiki/input/cursor-visibility-and-catching) | [Next](/wiki/input/on-screen-keyboard)

--- a/wiki/input/compass.md
+++ b/wiki/input/compass.md
@@ -28,5 +28,3 @@ The angles are given in degrees. Here's the interpretation of these values:
 Here's an illustration of the axis relative to the earth.
 
 ![images/compass.png](/assets/wiki/images/compass.png)
-
-[Prev](/wiki/input/accelerometer) | [Next](/wiki/input/vibrator)

--- a/wiki/input/configuration-and-querying.md
+++ b/wiki/input/configuration-and-querying.md
@@ -50,5 +50,3 @@ To check whether a specific input device is available on the platform the applic
 Please refer to the [Peripheral](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/Input.java#L560) enumeration to see the rest of the available constants.
 
 Note that only a few Android devices have a hardware keyboard. Even if the keyboard is physically present, the user might not have slid it out. The method shown above will return false in this case.
-
-[Next](/wiki/input/mouse-touch-and-keyboard)

--- a/wiki/input/cursor-visibility-and-catching.md
+++ b/wiki/input/cursor-visibility-and-catching.md
@@ -120,5 +120,3 @@ If you wish to let your HTML5 game use system cursors libGDX doesn't support, th
 * [CSS `cursor` values](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values)
 * [Interfacing with platform specific code](https://libgdx.com/wiki/app/interfacing-with-platform-specific-code)
 * [JSNI](http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html)
-
-[Prev](/wiki/input/vibrator) | [Next](/wiki/input/back-and-menu-key-catching)

--- a/wiki/input/event-handling.md
+++ b/wiki/input/event-handling.md
@@ -164,5 +164,3 @@ Then, in your Input processor:
 	    return true;
     }
 ```
-
-[Prev](/wiki/input/polling) | [Next](/wiki/input/controllers)

--- a/wiki/input/gesture-detection.md
+++ b/wiki/input/gesture-detection.md
@@ -82,5 +82,3 @@ The `GestureListener` can signal whether it consumed the event or wants it to be
 As with the events reported to a normal `InputProcessor`, the respective methods will be called right before the call to `ApplicationListener.render()` on the rendering thread.
 
 The `GestureDetector` also has a second constructor that allows it to specify various parameters for gesture detection. Please refer to the [Javadocs](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/input/GestureDetector.html#GestureDetector(float,%20float,%20float,%20float,%20com.badlogic.gdx.input.GestureDetector.GestureListener)) for more information.
-
-[Prev](/wiki/input/controllers) | [Next](/wiki/input/simple-text-input)

--- a/wiki/input/input-handling.md
+++ b/wiki/input/input-handling.md
@@ -13,6 +13,3 @@ All of the input facilities are accessed via the [Input](https://github.com/libg
    // Check if the A key is pressed
    boolean isPressed = Gdx.input.isKeyPressed(Keys.A);
 ```
-
-
-[Next](/wiki/input/configuration-and-querying)

--- a/wiki/input/mouse-touch-and-keyboard.md
+++ b/wiki/input/mouse-touch-and-keyboard.md
@@ -123,5 +123,3 @@ public class SimplerTouchTest extends ApplicationAdapter implements InputProcess
 	}
 }
 ```
-
-[Prev](/wiki/input/configuration-and-querying) | [Next](/wiki/input/polling)

--- a/wiki/input/on-screen-keyboard.md
+++ b/wiki/input/on-screen-keyboard.md
@@ -12,5 +12,3 @@ Once visible, any key presses will be reported as [events](/wiki/input/event-han
 Note that there is currently a bug in the on-screen keyboard implementation when landscape mode is used on Android. The default Android on-screen keyboard can be switched for a custom keyboard, and many handset manufacturers like HTC make use of this. Sadly, their keyboard implementations tend to be buggy which leads to problems described in this [issue](https://code.google.com/p/libgdx/issues/detail?id=431). If you're using a buggy custom keyboard or your manufacturer supplied a buggy custom keyboard, [Google's keyboard](https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin&hl=en) works correctly with libGDX.
 
 On-screen keyboard functionality is only available the Android and iOS platforms.
-
-[Prev](/wiki/input/back-and-menu-key-catching)

--- a/wiki/input/polling.md
+++ b/wiki/input/polling.md
@@ -86,5 +86,3 @@ boolean rightPressed = Gdx.input.isButtonPressed(Input.Buttons.RIGHT);
 See the [Buttons](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/Input.Buttons.html) class for more constants.
 
 Note that on Android we only emulate the left mouse button. Any touch event will be interpreted as if it was issued with a left mouse button press. Touch screens obviously don't have a notion of left, right and middle button.
-
-[Prev](/wiki/input/mouse-touch-and-keyboard) | [Next](/wiki/input/event-handling)

--- a/wiki/input/simple-text-input.md
+++ b/wiki/input/simple-text-input.md
@@ -31,5 +31,3 @@ Gdx.input.getTextInput(listener, "Dialog Title", "Initial Textfield Value", "Hin
 ```
 
 The methods of the listener will be called on the rendering thread, right before the `ApplicationListener.render()` method is called.
-
-[Prev](/wiki/input/gesture-detection) | [Next](/wiki/input/accelerometer)

--- a/wiki/input/vibrator.md
+++ b/wiki/input/vibrator.md
@@ -28,5 +28,3 @@ Gdx.input.vibrate(new long[] { 0, 200, 200, 200}, -1);
 ```
 
 This will turn the vibrator on for 200 milliseconds, then turn it off for 200 milliseconds then on again for another 200 milliseconds. The second parameter specifies that the pattern should not be repeated. Refer to the [Javadocs](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/Input.html#vibrate(int)) for more information.
-
-[Prev](/wiki/input/compass) | [Next](/wiki/input/cursor-visibility-and-catching)

--- a/wiki/input/vibrator.md
+++ b/wiki/input/vibrator.md
@@ -104,8 +104,6 @@ boolean vibration = Gdx.input.isPeripheralAvailable(Input.Peripheral.Vibrator);
 boolean amplitude = Gdx.input.isPeripheralAvailable(Input.Peripheral.HapticFeedback);
 ```
 
-This will turn the vibrator on for 200 milliseconds, then turn it off for 200 milliseconds then on again for another 200 milliseconds. The second parameter specifies that the pattern should not be repeated. Refer to the [Javadocs](https://javadoc.io/doc/com.badlogicgames.gdx/gdx/latest/com/badlogic/gdx/Input.html#vibrate(int)) for more information.
-=======
 In the above example, each variable will be `true` under the following circumstances:
 
 |OS|`vibration`|`amplitude`|


### PR DESCRIPTION
I understand the intention behind these links, but they just don't work very well. They're only in a couple sections, they lead to dead ends, miss pages out, are in no particular order, and will be challenging to maintain if we go shuffling pages about.