### PR TITLE
Shake up the syntax highlighting

### DIFF
--- a/_posts/2021/2021-07-24-devlog-7-lwjgl3.md
+++ b/_posts/2021/2021-07-24-devlog-7-lwjgl3.md
@@ -86,7 +86,7 @@ Another viable approach for _outside of your development environment_ is to just
 - To use **Swing or AWT** APIs, you'll have to depend on the ([experimental](https://github.com/libgdx/libgdx/issues?q=is%3Aissue+is%3Aopen+label%3Aglfw-awt-macos)) gdx-lwjgl3-glfw-awt-macos extension. See [`AwtTestLWJGL`](https://github.com/libgdx/libgdx/blob/master/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/AwtTestLWJGL.java) in gdx-tests-lwjgl3 for an example.
 - The LWJGL 3 backend does [not yet](https://github.com/libgdx/libgdx/pull/6247) have an equivalent for `LwjglAWTCanvas` and `LwjglAWTFrame`.
 - As the graphical tools in **gdx-tools** require the `LwjglAWTCanvas` class, the library has a hard dependency on LWJGL 2. If you are using one of the non-graphical tools of the gdx-tools project (in particular [TexturePacker](/wiki/tools/texture-packer#from-source)) and the LWJGL 3 backend _in the same (!) project_, you need to modify your gdx-tools dependency like this:
-   ```groovy
+   ```gradle
    compile ("com.badlogicgames.gdx:gdx-tools:$gdxVersion") {
       exclude group: 'com.badlogicgames.gdx', module: 'gdx-backend-lwjgl'
    }

--- a/wiki/articles/dependency-management-with-gradle.md
+++ b/wiki/articles/dependency-management-with-gradle.md
@@ -30,7 +30,7 @@ The root directory, and each sub directory contains a `build.gradle` file, for c
 Here is a small section of the _default_ buildscript that is generated from the setup:
 
 _Full script you will see will differ slightly depending on what other modules you have_
-```groovy
+```gradle
 //Configuration for the script itself (aka, listing the dependencies of the script that lists dependencies - InSCRIPTion!)
 buildscript {
     //Defines the repositories required by this script, e.g. hosting the android plugin
@@ -119,14 +119,14 @@ In order to add an external dependency to a project, you must declare the depend
 
 (Some) libGDX extensions are mavenized and pushed to the maven repo, which means we can very easily pull them into our projects from the `build.gradle` file. You can see in the list [below](#libgdx-extensions) of the format that these dependencies take.
 If you are familiar with maven, notice the format:
-```groovy
+```gradle
 implementation '<groupId>:<artifactId>:<version>:<classifier>'
 ```
 
 Let's take a quick example to see how this works with the android `build.gradle` file.
 
 [Here](#freetypefont-gradle) we see the dependencies for the FreeType Extension, say we want our Android project to have this dependency:
-```groovy
+```gradle
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
     implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
@@ -140,7 +140,7 @@ dependencies {
 ```
 
 **We know our FreeType extension has the following android declarations:**
-```groovy
+```gradle
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86"
@@ -149,7 +149,7 @@ natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86_64"
 
 **So all we need to do is whack it in the dependencies stub**
 
-```groovy
+```gradle
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
     implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
@@ -168,7 +168,7 @@ dependencies {
 
 **Ensure that your Core project has the freetype extension in core/build.gradle**
 
-```groovy
+```gradle
 dependencies {
   api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
   api "com.badlogicgames.gdx:gdx:$gdxVersion"
@@ -190,26 +190,26 @@ Mavenized libGDX extensions ready to import from the `build.gradle` script inclu
 
 #### Box2D Gradle
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
 ```
 **Desktop Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
 ```
 **Android Dependency:**
-```groovy
+```gradle
 natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-arm64-v8a"
 natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a"
 natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86"
 natives "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86_64"
 ```
 **iOS Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-ios"
 ```
 **HTML Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion:sources"
 implementation("com.badlogicgames.gdx:gdx-box2d-gwt:$gdxVersion:sources") {exclude group: "com.google.gwt", module: "gwt-user"}
 ```
@@ -219,15 +219,15 @@ and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="c
 
 #### Bullet Gradle
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.gdx:gdx-bullet:$gdxVersion"
 ```
 **Desktop Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-desktop"
 ```
 **Android Dependency:**
-```groovy
+```gradle
 natives "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-arm64-v8a"
 natives "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-armeabi-v7a"
 natives "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-x86"
@@ -235,7 +235,7 @@ natives "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-x86_64"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a"
 ```
 **iOS Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-ios"
 ```
 **HTML Dependency:**
@@ -245,26 +245,26 @@ Not compatible!
 
 #### FreeTypeFont Gradle
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
 ```
 **Desktop Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-desktop"
 ```
 **Android Dependency:**
-```groovy
+```gradle
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86"
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86_64"
 ```
 **iOS Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-ios"
 ```
 **iOS-MOE Dependency:**
-```groovy
+```gradle
 natives "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-ios"
 ```
 **HTML Dependency:**
@@ -274,24 +274,24 @@ Not compatible! See [gdx-freetype-gwt](https://github.com/intrigus/gdx-freetype-
 
 #### Controllers Gradle
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.gdx-controllers:gdx-controllers-core:$gdxControllersVersion"
 ```
 **Desktop Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx-controllers:gdx-controllers-desktop:$gdxControllersVersion"
 ```
 **Android Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx-controllers:gdx-controllers-android:$gdxControllersVersion"
 ```
 **iOS Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx-controllers:gdx-controllers-ios:$gdxControllersVersion"
 ```
 
 **HTML Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx-controllers:gdx-controllers-core:$gdxControllersVersion:sources"
 implementation("com.badlogicgames.gdx-controllers:gdx-controllers-gwt:$gdxControllersVersion:sources"){exclude group: "com.badlogicgames.gdx", module: "gdx-backend-gwt"}
 ```
@@ -304,7 +304,7 @@ and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="c
 Don't put me in core!
 
 **Desktop Dependency (LWJGL2 Legacy Desktop only):**
-```groovy
+```gradle
 api "com.badlogicgames.gdx:gdx-tools:$gdxVersion"
 ```
 **Android Dependency:**
@@ -322,7 +322,7 @@ Not compatible!
 * **Note:** this extension also requires the [Box2D](#box2d-gradle) extension
 
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.box2dlights:box2dlights:$box2dlightsVersion"
 ```
 **Desktop Dependency:**
@@ -332,7 +332,7 @@ No native dependency required.
 No native dependency required.
 
 **HTML Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.box2dlights:box2dlights:$box2dlightsVersion:sources"
 ```
 and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="Box2DLights" />`
@@ -344,7 +344,7 @@ and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="B
 * **Note:** This extension release cycle is not dependent on the main libGDX library, and so it is not unusual to have a new version published between two libGDX releases. If you want to pull in a new (or different) version, check [https://repo1.maven.org/maven2/com/badlogicgames/ashley/ashley/](https://repo1.maven.org/maven2/com/badlogicgames/ashley/ashley/) and change the `ashleyVersion` value in the `ext` section.
 
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.ashley:ashley:$ashleyVersion"
 ```
 
@@ -355,7 +355,7 @@ No native dependency required.
 No native dependency required.
 
 **HTML Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.ashley:ashley:$ashleyVersion:sources"
 ```
 and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="com.badlogic.ashley_gwt" />`
@@ -367,7 +367,7 @@ and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="c
 * **Note:** This extension release cycle is not dependent on the main libGDX library, and so it is not unusual to have a new version published between two libGDX releases. If you want to pull in a new (or different) version, check [https://repo1.maven.org/maven2/com/badlogicgames/gdx/gdx-ai/](https://repo1.maven.org/maven2/com/badlogicgames/gdx/gdx-ai/) and change the `aiVersion` value in the `ext` section.
 
 **Core Dependency:**
-```groovy
+```gradle
 api "com.badlogicgames.gdx:gdx-ai:$aiVersion"
 ```
 
@@ -378,7 +378,7 @@ No native dependency required.
 No native dependency required.
 
 **HTML Dependency:**
-```groovy
+```gradle
 implementation "com.badlogicgames.gdx:gdx-ai:$aiVersion:sources"
 ```
 and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="com.badlogic.gdx.ai" />`
@@ -392,7 +392,7 @@ and in `./html/src/yourgamedomain/GdxDefinition*.gwt.xml` add `<inherits name="c
 Gradle finds files defined as dependencies by looking through all the repositories defined in the buildscript. Gradle understands several repository formats, which include Maven and Ivy.
 
 Under the `subprojects` stub of the root build.gradle, you can see how repositories are defined. Here is an example:
-```groovy
+```gradle
 subprojects {
     version = '1.0.0'
     ext.appName = 'MyOriginalGame'
@@ -410,14 +410,14 @@ subprojects {
 #### Adding Dependencies
 External dependencies are identified by their group, name, version and sometimes classifier attributes.
 
-```groovy
+```gradle
 dependencies {
     implementation group: 'com.badlogicgames.gdx', name: 'gdx', version: '1.0-SNAPSHOT', classifier: 'natives-desktop'
 }
 ```
 Gradle allows you to use shortcuts when defining external dependencies, the above configuration is the same as:
 
-```groovy
+```gradle
 dependencies {
     implementation 'com.badlogicgames.gdx:gdx:1.0-SNAPSHOT:natives-desktop'
 }
@@ -434,7 +434,7 @@ mvn install:install-file -Dfile=<path-to-source-file> -DgroupId=<group-id> -Dart
 ```
 
 To then set up gradle to include your new dependency, edit your build.gradle file in the root project directory and edit the core project entry:
-```groovy
+```gradle
 project(":core") {
    ...
 
@@ -458,7 +458,7 @@ If you have a dependency that is not mavenized, you can still depend on them!
 
 To do this, in your project stub in the subproject's corresponding `build.gradle` file, locate the dependencies { } section and add the following:
 
-```groovy
+```gradle
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
 }
@@ -470,7 +470,7 @@ This will include all the .jar files in the libs directory as dependencies.
 **NOTE**: "dir" is relative to the project root, if you add the dependencies to your android project, 'libs' would need to be in the android/ directory. If you added the dependencies in the core project, 'libs' would need to be in the core/ directory.
 
 An example with a more _complete_ script:
-```groovy
+```gradle
 project(":android") {
     apply plugin: "android"
 
@@ -501,7 +501,7 @@ When adding `flat file` dependencies to a project, for example the core project,
 
 For example, if you were to add the all the jars in your `libs` directory as dependencies for your project, you would need to do the following.
 
-```groovy
+```gradle
 project(":core") {
    ...
    implementation fileTree(dir: '../libs', include: '*.jar')

--- a/wiki/articles/improving-workflow-with-gradle.md
+++ b/wiki/articles/improving-workflow-with-gradle.md
@@ -55,7 +55,7 @@ It also allows you to keep the power of Gradle at your disposal, to handle all y
 ### Creating your IDEA project
 From the command line, run the following command from your project root directory:
 (If on a UNIX based OS, use ./gradlew to invoke gradle)
-```groovy
+```gradle
 gradlew idea
 ```
 
@@ -64,7 +64,7 @@ File > OPEN > Locate the .ipr that the task above generates
 ### Creating your Eclipse Project
 From the command line, run the following command from your project root directory:
 (If on a UNIX based OS, use ./gradlew to invoke gradle)
-```groovy
+```gradle
 gradlew eclipse
 ```
 

--- a/wiki/articles/updating-libgdx.md
+++ b/wiki/articles/updating-libgdx.md
@@ -13,7 +13,7 @@ libGDX's Gradle based projects make it very easy to switch between libGDX versio
 
 Your Gradle based project makes it very easy to switch between releases and nightly builds. Open up the `gradle.properties` file in the root of your project, and locate the following line:
 
-```groovy
+```gradle
 gdxVersion=1.12.1
 ```
 

--- a/wiki/graphics/2d/imgui.md
+++ b/wiki/graphics/2d/imgui.md
@@ -53,7 +53,7 @@ IO.fonts.addFontFromFileTTF("extraFonts/ArialUni.ttf", 18f, glyphRanges = IO.fon
 
 # Option 2: [SpaiR's Bindings](https://github.com/SpaiR/imgui-java)
 ### Required Dependencies for the LWJGL 3 Subproject
-```groovy
+```gradle
 api "io.github.spair:imgui-java-binding:<version>"
 api "io.github.spair:imgui-java-lwjgl3:<version>"
 api "io.github.spair:imgui-java-natives-linux:<version>"

--- a/wiki/internationalization-and-localization.md
+++ b/wiki/internationalization-and-localization.md
@@ -27,7 +27,7 @@ game=My Super Cool Game
 newMission={0}, you have a new mission. Reach level {1}.
 coveredPath=You covered {0,number}% of the path
 highScoreTime=High score achieved on {0,date} at {0,time}
-````
+```
 
 To support an additional Locale, your localizers will create an _additional properties file_ that contains the translated values. No changes to your source code are required, because your program references the keys, not the values.
 
@@ -46,11 +46,11 @@ Notice that the key named `game` is missing from the Italian properties file sin
 
 An instance of the `I18NBundle` class manages the named strings for a locale after loading into memory the appropriate properties files.
 Invoke the factory method `createBundle` to get a new instance of the desired bundle:
-````java
+```java
 FileHandle baseFileHandle = Gdx.files.internal("i18n/MyBundle");
 Locale locale = new Locale("fr", "CA", "VAR1");
 I18NBundle myBundle = I18NBundle.createBundle(baseFileHandle, locale);
-````
+```
 
 The path "i18n/MyBundle", in this case, refers to files whose names begin with _MyBundle_ that are located in the _i18n_ folder, more precisely in "assets/i18n". You do not need to create the _MyBundle_ subfolder as well.
 

--- a/wiki/internationalization-and-localization.md
+++ b/wiki/internationalization-and-localization.md
@@ -22,7 +22,7 @@ Each bundle is a set of properties files that share the same base name, `MyBundl
 `MyBundle_en_GB`, for example, matches the Locale specified by the language code for English (`en`) and the country code for Great Britain (`GB`).
 
 You should always create a _default properties file_, without any language code, country code or variant. In our example the contents of `MyBundle.properties` are as follows:
-````
+```properties
 game=My Super Cool Game
 newMission={0}, you have a new mission. Reach level {1}.
 coveredPath=You covered {0,number}% of the path
@@ -33,11 +33,11 @@ To support an additional Locale, your localizers will create an _additional prop
 
 For example, to add support for the Italian language, your localizers would translate the values in `MyBundle.properties` and place them in a file named `MyBundle_it.properties`. The contents of `MyBundle_it.properties` are as follows:
 
-````
+```properties
 newMission={0}, hai una nuova missione. Raggiungi il livello {1}.
 coveredPath=Hai coperto il {0,number}% del percorso
 highScoreTime=High score ottenuto il {0,date} alle ore {0,time}
-````
+```
 Notice that the key named `game` is missing from the Italian properties file since we want the game's name to remain unchanged regardless of the locale. If a key is not found, the key will be looked up in decreasingly specific properties files until found; for instance, if a key is not found in `MyBundle_en_GB.properties`, it will be looked up in `MyBundle_en.properties`, and if not found there either, in the default `MyBundle.properties`.
 
 
@@ -55,7 +55,7 @@ I18NBundle myBundle = I18NBundle.createBundle(baseFileHandle, locale);
 The path "i18n/MyBundle", in this case, refers to files whose names begin with _MyBundle_ that are located in the _i18n_ folder, more precisely in "assets/i18n". You do not need to create the _MyBundle_ subfolder as well.
 
 Or, if you're using [`AssetManager`](/wiki/managing-your-assets):
-```
+```java
 assetManager.load("i18n/MyBundle", I18NBundle.class);
 // ... after loading ...
 I18NBundle myBundle = assetManager.get("i18n/MyBundle", I18NBundle.class);
@@ -77,23 +77,23 @@ Note that `createBundle` looks for files based on the default Locale before it s
 ## Fetching Localized Strings
 
 To retrieve a translated value from the bundle, invoke the `get` method as follows:
-````java
+```java
 String value = myBundle.get(key);
-````
+```
 The string returned by the `get` method corresponds to the specified key. The string is in the proper language, provided that a properties file exists for the specified locale. If no string for the given key can be found by the `get` method (or its parametric form `format`) a `MissingResourceException` is thrown.
 
 Translated strings can contain formatting parameters. To substitute values for those, invoke the `format` method as follows:
-````java
+```java
 String value = myBundle.format(key, arg1, arg2, ...);
-````
+```
 
 For example, to retrieve the strings from the properties files above your code might look like this:
-````java
+```java
 String game = myBundle.format("game");
 String mission = myBundle.format("newMission", player.getName(), nextLevel.getName());
 String coveredPath = myBundle.format("coveredPath", path.getPerc());
 String highScoreTime = myBundle.format("highScoreTime", highScore.getDate());
-````
+```
 
 When a string has no arguments, you might think that the methods `get` and `format` are equivalent. This is not entirely true. The `get` method returns the string exactly as it was specified in the properties file, while the `format` method might make replacements for escaping even if no arguments are present. As a result, `get` is slightly faster, but unless you are certain that none of your translations contain any escaping it's best to always use `format`.
 
@@ -116,23 +116,23 @@ Unlike `java.util.Properties`, the default encoding is `UTF-8`. If, for whatever
 Plural forms are supported through the standard `choice` format provided by `MessageFormat`.
 See the [official documentation of the class `java.text.ChoiceFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/ChoiceFormat.html).
 I'm going to show you just an example. Let's consider the following property:
-````
+```properties
 collectedCoins=You collected {0,choice,0#no coins|1#one coin|1<{0,number,integer} coins|100<hundreds of coins} along the path.
-````
+```
 You can retrieve the localized string as usual:
-````java
+```java
 System.out.println(myBundle.format("collectedCoins", 0));
 System.out.println(myBundle.format("collectedCoins", 1));
 System.out.println(myBundle.format("collectedCoins", 32));
 System.out.println(myBundle.format("collectedCoins", 117));
-````
+```
 And the output result would be like the following:
-````
+```
 You collected no coins along the path.
 You collected one coin along the path.
 You collected 32 coins along the path.
 You collected hundreds of coins along the path.
-````
+```
 
 It's worth noting that the choice format can properly handle nested formats as we did with `{0,number,integer}` inside `{0,choice,...}`.
 

--- a/wiki/jvm-langs/using-libgdx-with-kotlin.md
+++ b/wiki/jvm-langs/using-libgdx-with-kotlin.md
@@ -50,7 +50,7 @@ This step basically includes following the [instructions from the official Kotli
 
 Add the following to your parent project’s `build.gradle`:
 
-```Groovy
+```gradle
 buildscript {
     ext.kotlinVersion = '<version to use>'
 
@@ -72,7 +72,7 @@ In the android sub-project, add `apply plugin: "kotlin-android"` after the `appl
 
 Add Kotlin’s stdlib to your core project's dependencies list:
 
-```Groovy
+```gradle
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }

--- a/wiki/jvm-langs/using-libgdx-with-scala.md
+++ b/wiki/jvm-langs/using-libgdx-with-scala.md
@@ -26,7 +26,7 @@ In order to support Scala compilation you need to update the build with a couple
     - **optional** Set the src directory for scala files: `sourceSets.main.scala.srcDirs = [ "src/" ]`
 - <root>/android/build.gradle
     - In the `android` section (top of the file) you need to add the following:
-        ```groovy
+        ```gradle
         lintOptions {
             abortOnError false // make sure you're paying attention to the linter output!
         }

--- a/wiki/jvm-langs/using-libgdx-with-scala.md
+++ b/wiki/jvm-langs/using-libgdx-with-scala.md
@@ -26,33 +26,33 @@ In order to support Scala compilation you need to update the build with a couple
     - **optional** Set the src directory for scala files: `sourceSets.main.scala.srcDirs = [ "src/" ]`
 - <root>/android/build.gradle
     - In the `android` section (top of the file) you need to add the following:
-        ```gradle
-        lintOptions {
-            abortOnError false // make sure you're paying attention to the linter output!
-        }
+      ```gradle
+      lintOptions {
+          abortOnError false // make sure you're paying attention to the linter output!
+      }
 
-        // FIXME: How can we apply this simply for all builds? Copy-pasta makes me sad.
-        buildTypes {
-            release {
-                minifyEnabled true
-                proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
-                proguardFile 'proguard-project.txt'
-            }
-            debug {
-                minifyEnabled true
-                proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
-                proguardFile 'proguard-project.txt'
-            }
-        }
-        ```
+      // FIXME: How can we apply this simply for all builds? Copy-pasta makes me sad.
+      buildTypes {
+          release {
+              minifyEnabled true
+              proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
+              proguardFile 'proguard-project.txt'
+          }
+          debug {
+              minifyEnabled true
+              proguardFile getDefaultProguardFile('proguard-android-optimize.txt')
+              proguardFile 'proguard-project.txt'
+          }
+      }
+      ```
 - <root>/android/proguard-project.txt
     - In order for Proguard to work you need to add the following lines:
 
-        ```
-        -dontwarn sun.misc.*
-        -dontwarn java.lang.management.**
-        -dontwarn java.beans.**
-        ```
+      ```
+      -dontwarn sun.misc.*
+      -dontwarn java.lang.management.**
+      -dontwarn java.beans.**
+      ```
     - It might also be required to then change the line `-dontwarn com.badlogic.gdx.jnigen.BuildTarget*` to `-dontwarn com.badlogic.gdx.jnigen.*`
 
 With all of these changes in-place you should be able to use Gradle exactly as you would otherwise from the shell or your favorite IDE.

--- a/wiki/third-party/google-play-games-services-in-libgdx.md
+++ b/wiki/third-party/google-play-games-services-in-libgdx.md
@@ -31,11 +31,11 @@ Latest tutorial using Android Studio can be found [here](https://chandruscm.word
    * Google Repository
 2. Download the BaseGameUtils sample project [here](https://github.com/playgameservices/android-basic-samples), copy folder `BaseGameUtils`, located in folder `BasicSamples` into your project root folder.
 3. Edit `settings.gradle`
-   ```groovy
+   ```gradle
    include 'desktop', 'android', 'ios', 'html', 'core', "BaseGameUtils"
    ```
 4. Edit root `build.gradle` and add the below as android dependency:
-   ```groovy
+   ```gradle
    compile project(":BaseGameUtils")
    ```
 5. in your `AndroidManifest.xml` file

--- a/wiki/third-party/proguard-dexguard-and-libgdx.md
+++ b/wiki/third-party/proguard-dexguard-and-libgdx.md
@@ -54,7 +54,7 @@ Note that you will also have to keep any classes that you access via reflection 
 To apply ProGuard/R8 to your Android project on Release builds, you need to add the following config to `build.gradle` file (the one in the `android/` folder of your project, not the root `build.gradle`)
 
 
-```groovy
+```gradle
 buildTypes {
         release {
             minifyEnabled true

--- a/wiki/utils/jnigen.md
+++ b/wiki/utils/jnigen.md
@@ -116,7 +116,7 @@ jnigen outputs the Java line numbers in the generated native code, telling us wh
 
 The recommended way to use jnigen is through the gradle plugin, even though it is not requiered.  
 First of all, you need to apply the jnigen plugin:  
-```groovy
+```gradle
 // Add buildscript dependency
 buildscript {
     dependencies {


### PR DESCRIPTION
* Bulk change from `groovy` to `gradle`. In many cases this doesn't make a difference, but in some places it gives us Gradle-specific syntax highlighting, most noticeable on the dependency management page where blocks such as `dependencies` become highlighted. Most of the wiki used <code>```groovy</code>, so please shout if I'm doing something stupid.
* Use <code>```properties</code>. It works!