### PR TITLE
Fix scene2d-ui "Usage without touch or mouse" link

### DIFF
--- a/wiki/graphics/2d/scene2d/scene2d-ui.md
+++ b/wiki/graphics/2d/scene2d/scene2d-ui.md
@@ -45,7 +45,7 @@ Check out [libGDX.info](https://libgdxinfo.wordpress.com/) for examples showcasi
    * [Dialog](#dialog)
  * [Widgets without scene2d.ui](#widgets-without-scene2dui)
  * [Drag and Drop](#drag-and-drop-draganddrop-class)
- * [Usage without touch or mouse](#Keycontrol)
+ * [Usage without touch or mouse](#usage-without-touch-or-mouse)
  * [Examples](#examples)
 
 # Widget and WidgetGroup


### PR DESCRIPTION
The `Usage without touch or mouse` link did not scroll down to where it should, the id was not matching where the link wanted to go