### PR TITLE
new frame for latest SpaiR

### DIFF
--- a/wiki/graphics/2d/imgui.md
+++ b/wiki/graphics/2d/imgui.md
@@ -65,7 +65,8 @@ The following instructions detail how ImGui can be used in a libGDX game. For ea
          Gdx.input.setInputProcessor(tmpProcessor);
          tmpProcessor = null;
       }
-
+      
+      imGuiGl3.newFrame();
       imGuiGlfw.newFrame();
       ImGui.newFrame();
    }


### PR DESCRIPTION
As current version of SpaiR (1.87.3), the **newFrame** should call three times with imGuiGl3, imGuiGlfw and ImGui so that we could correctly run the code