### PR TITLE
Fix indentation of example code in rendering-shapes.md

### DIFF
--- a/wiki/graphics/opengl-utils/rendering-shapes.md
+++ b/wiki/graphics/opengl-utils/rendering-shapes.md
@@ -11,59 +11,59 @@ Example code that is taken from an actual project:
 
 ```java
 public class MyGame extends Game {
-        public final static float WIDTH = 100;
-        public final static float HEIGHT = 16 * WIDTH / 9;
+	public final static float WIDTH = 100;
+	public final static float HEIGHT = 16 * WIDTH / 9;
 
-        FitViewport viewport;
+	FitViewport viewport;
 	OrthographicCamera camera;
-        ShapeRenderer shape;
+	ShapeRenderer shape;
 
-        @Override
+	@Override
 	public void create () {
 		shape = new ShapeRenderer();
 		camera = new OrthographicCamera();
 		viewport = new FitViewport(WIDTH, HEIGHT, camera);
-                ...
-        }
+		...
+	}
 
-        @Override
+	@Override
 	public void resize(int width, int height) {
 		viewport.update(width, height);
 	}
 
-        ...
+	...
 }
 
 public class Box {
-        ...
+	...
 }
 
 public class ScreenPlay implements Screen {
-        final Game g;
-        Array<Box> boxes;
-        ...
-        
-        @Override
+	final Game g;
+	Array<Box> boxes;
+	...
+
+	@Override
 	public void render(float delta) {
-              for(Box box : boxes) {
+		for(Box box : boxes) {
 			g.shape.setProjectionMatrix(g.camera.combined);
 			g.shape.begin(ShapeType.Line);
 			g.shape.setColor(Color.RED);
 			g.shape.rect(box.x, box.y, box.width, box.height);
 			g.shape.end();
-			
+
 			g.shape.setProjectionMatrix(g.camera.combined);
 			g.shape.begin(ShapeType.Filled);
 			g.shape.setColor(Color.BLUE);
 			g.shape.ellipse(box.x, box.y, box.width, box.height);
 			g.shape.end();
-		}	
-        }
+		}
+	}
 
-        ...
+	...
 
 }
-```  
+```
 
 ### Alternatives
 


### PR DESCRIPTION
This example code had a mix of tab and space indentation which showed up when rendered.