### PR TITLE
Add width and height parameters to embed-gwt.html and make it responsive

### DIFF
--- a/_includes/embed-gwt.html
+++ b/_includes/embed-gwt.html
@@ -1,12 +1,40 @@
 <style>
     .embed-container {
-      position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;
+        position: relative;
+        max-width: 100%;
+        margin: 1em auto; /* auto left and right to center div in case width is smaller than available space */
+
+        {% if include.width and include.height %}
+            /* set width and height explicitly if they are given */
+            width: {{include.width}}px;
+            height: {{include.height}}px;
+        {% else %}
+            /* otherwise default to 16:9 ratio */
+            height: 0;
+            padding-bottom: 56.25%;
+        {% endif %}
     }
-    .embed-container iframe , .embed-container object, .embed-container embed {
-      position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+
+    /* set height based on ratio if screen width is smaller than given width to avoid black bars */
+    {% if include.width and include.height %}
+        @media only screen and (max-width: {{include.width}}px) {
+            .embed-container {
+                height: 0;
+                padding-bottom: calc({{include.height}} / {{include.width}} * 100%);
+            }
+        }
+    {% endif %}
+
+    .embed-container iframe, .embed-container object, .embed-container embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
     }
+
     .embed-container iframe {
-      border:0;
+        border: 0;
     }
 </style>
 

--- a/wiki/misc/wiki-style-guide.md
+++ b/wiki/misc/wiki-style-guide.md
@@ -81,10 +81,12 @@ Videos can be included like this:
 
 Actual libGDX examples can be embedded via GWT as iframes. To do this, use the `embed-gwt` element on a wiki page:
 ```yml
-{% raw %}{% include embed-gwt.html dir='viewport-example' %}{% endraw %}
+{% raw %}{% include embed-gwt.html dir='viewport-example' width="800" height="500" %}{% endraw %}
 ```
 
 `dir` refers to the directory in the [libgdx-wiki-examples](https://github.com/libgdx/libgdx-wiki-examples) repo, where the source code of the examples is located. In particular, it denotes the path to the root folder of the example's Gradle project (without leading and trailing slashes; in this case, `viewport-example` refers to the  `/viewport-example/` folder which contains `/html/build.gradle`). The examples are automatically built via GH Actions (by calling `./gradlew html:dist`) and then deployed through GH Pages.
+
+If `width` and `height` are **both** set they are used for the container dimensions. They represent the dimensions in pixels and must be given as raw numbers without units.
 
 To style the embedded content, use the `containerstyle` and `iframestyle` attributes.
 

--- a/wiki/start/a-simple-game.md
+++ b/wiki/start/a-simple-game.md
@@ -7,7 +7,7 @@ redirect_from:
 
 Let's make a game! Game design is hard, but if you break up the process into small, achievable goals, you'll be able to produce wonders. In this simple game tutorial, you will learn how to make a basic game from scratch. These are the essential skills that you will build on in future projects. You may watch the [video tutorial](https://youtu.be/aipDYyh1Mlc), however you should come back here for the code examples.
 
-{% include embed-gwt.html dir='a-simple-game' %}
+{% include embed-gwt.html dir='a-simple-game' width="800" height="500" %}
 
 As you can see with the live demo, we're going to make a basic game where you control a bucket to collect water droplets falling from the sky. There is no score or end goal. Just enjoy the experience! Here are the steps that we will use to split up the game design process:
 


### PR DESCRIPTION
### Problem

By default the container in embed-gwt.html has a dynamic width and a fixed 16:9 aspect ratio (achieved through padding-bottom method).

However A Simple Game uses a FitViewport with a different aspect ratio and a 800x500 px resolution. As you can see this causes black bars and the dynamic width causes ugly scaling artifacts on the bucket and droplet textures. The black bars would be even worse if you had a game that used portrait mode.

<img width="995" height="820" alt="image" src="https://github.com/user-attachments/assets/105c93b6-0b12-4fd7-adea-c8c255ea7e19" />

You could set the width and height through the `containerstyle` parameter. But then you would also have to know to overwrite `padding-bottom` which doesn't make sense as an interface user. Even if you did you'd have a fixed height which would still cause black bars when the available width is smaller than the given width.

### Solution

I added `width` and `height` parameters to embed-gwt.html. If they are both passed they're used to explicitly set the container dimensions. Otherwise the default aspect ratio is used as before.

In case the screen width is smaller than the given `width` parameter, the correct aspect ratio is set through the padding-bottom method. This prevents black bars when the available width is smaller than the given width.

### Result

<img width="994" height="796" alt="image" src="https://github.com/user-attachments/assets/1f845001-fa3a-45e9-96bf-9b535fe158a3" />

### Limitations

Setting the aspect ratio for small screen sizes doesn't work perfectly in all cases. The screen width is not equal to the available width due to the sidebar and some padding, so there's still a small range where you can have black bars but it's miniscule as you can see in this video:

[A Simple Game - libGDX - Google Chrome 2025-12-29 20-31-27.webm](https://github.com/user-attachments/assets/4cf1e69b-b6a2-43d8-a3a2-d29c9191df4c)
